### PR TITLE
CEDS-1204 Clean up IntelliJ Errors

### DIFF
--- a/app/views/arrival_details.scala.html
+++ b/app/views/arrival_details.scala.html
@@ -30,7 +30,7 @@
     @helper.form(routes.MovementDetailsController.saveMovementDetails(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
-        @components.back_link("/customs-movements/consignment-references")
+        @components.back_link(routes.ConsignmentReferencesController.displayPage())
 
         @components.error_summary(form.errors)
 

--- a/app/views/arrival_details.scala.html
+++ b/app/views/arrival_details.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import config.AppConfig
-@import controllers.routes._
+@import controllers.routes
 @import uk.gov.hmrc.play.views.html._
 @import forms.ArrivalDetails
 
@@ -27,7 +27,7 @@
     title = messages("arrivalDetails.title"),
     appConfig = appConfig
 ) {
-    @helper.form(MovementDetailsController.saveMovementDetails(), 'autoComplete -> "off") {
+    @helper.form(routes.MovementDetailsController.saveMovementDetails(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
         @components.back_link("/customs-movements/consignment-references")

--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -33,7 +33,7 @@
     @helper.form(routes.ChoiceController.submitChoice(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
-        @components.back_link("start")
+        @components.back_link(routes.StartController.displayStartPage())
 
         @components.heading("", "movement.choice.description")
 

--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -19,7 +19,7 @@
 @import forms.Choice
 @import forms.Choice.AllowedChoiceValues
 @import uk.gov.hmrc.play.views.html._
-@import views.components.RadioOption
+@import views.components.fields.RadioOption
 
 @this(main_template: views.html.main_template)
 

--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -15,11 +15,11 @@
  *@
 
 @import config.AppConfig
-@import controllers.routes._
+@import controllers.routes
 @import forms.Choice
 @import forms.Choice.AllowedChoiceValues
 @import uk.gov.hmrc.play.views.html._
-@import utils.RadioOption
+@import views.components.RadioOption
 
 @this(main_template: views.html.main_template)
 
@@ -30,7 +30,7 @@
     appConfig = appConfig
 ) {
 
-    @helper.form(ChoiceController.submitChoice(), 'autoComplete -> "off") {
+    @helper.form(routes.ChoiceController.submitChoice(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
         @components.back_link("start")

--- a/app/views/components/RadioOption.scala
+++ b/app/views/components/RadioOption.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package utils
+package views.components
 
 case class RadioOption(id: String, value: String, messageKey: String, hint: Option[String] = None)
 

--- a/app/views/components/back_link.scala.html
+++ b/app/views/components/back_link.scala.html
@@ -14,8 +14,8 @@
  * limitations under the License.
  *@
 
-@(href: String)(implicit messages: Messages)
+@(href: Call)(implicit messages: Messages)
 
 <div class="js-visible">
-    <a id="link-back" class="link-back" href="@href">@messages("site.back")</a>
+    <a id="link-back" class="link-back" href="@{href.url}">@messages("site.back")</a>
 </div>

--- a/app/views/components/fields/RadioOption.scala
+++ b/app/views/components/fields/RadioOption.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package views.components
+package views.components.fields
 
 case class RadioOption(id: String, value: String, messageKey: String, hint: Option[String] = None)
 

--- a/app/views/components/input_radio.scala.html
+++ b/app/views/components/input_radio.scala.html
@@ -14,8 +14,7 @@
  * limitations under the License.
  *@
 
-@import utils.RadioOption
-
+@import views.components.RadioOption
 @(
     field: Field,
     legend: String,

--- a/app/views/components/input_radio.scala.html
+++ b/app/views/components/input_radio.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import views.components.RadioOption
+@import views.components.fields.RadioOption
 @(
     field: Field,
     legend: String,

--- a/app/views/consignment_references.scala.html
+++ b/app/views/consignment_references.scala.html
@@ -15,11 +15,11 @@
  *@
 
 @import config.AppConfig
-@import controllers.routes._
+@import controllers.routes
 @import uk.gov.hmrc.play.views.html._
 @import forms.ConsignmentReferences
 @import forms.ConsignmentReferences.AllowedReferences._
-@import utils.RadioOption
+@import views.components.RadioOption
 
 @this(main_template: views.html.main_template)
 
@@ -29,7 +29,7 @@
     title = messages("consignmentReferences.title"),
     appConfig = appConfig
 ) {
-    @helper.form(ConsignmentReferencesController.saveConsignmentReferences(), 'autoComplete -> "off") {
+    @helper.form(routes.ConsignmentReferencesController.saveConsignmentReferences(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
         @components.back_link("/customs-movements/choice")

--- a/app/views/consignment_references.scala.html
+++ b/app/views/consignment_references.scala.html
@@ -19,7 +19,7 @@
 @import uk.gov.hmrc.play.views.html._
 @import forms.ConsignmentReferences
 @import forms.ConsignmentReferences.AllowedReferences._
-@import views.components.RadioOption
+@import views.components.fields.RadioOption
 
 @this(main_template: views.html.main_template)
 

--- a/app/views/consignment_references.scala.html
+++ b/app/views/consignment_references.scala.html
@@ -32,7 +32,7 @@
     @helper.form(routes.ConsignmentReferencesController.saveConsignmentReferences(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
-        @components.back_link("/customs-movements/choice")
+        @components.back_link(routes.ChoiceController.displayChoiceForm())
 
         @components.error_summary(form.errors)
 

--- a/app/views/departure_details.scala.html
+++ b/app/views/departure_details.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import config.AppConfig
-@import controllers.routes._
+@import controllers.routes
 @import uk.gov.hmrc.play.views.html._
 @import forms.DepartureDetails
 
@@ -27,7 +27,7 @@
     title = messages("departureDetails.title"),
     appConfig = appConfig
 ) {
-    @helper.form(MovementDetailsController.saveMovementDetails(), 'autoComplete -> "off") {
+    @helper.form(routes.MovementDetailsController.saveMovementDetails(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
         @components.back_link("/customs-movements/goods-departed")

--- a/app/views/departure_details.scala.html
+++ b/app/views/departure_details.scala.html
@@ -30,7 +30,7 @@
     @helper.form(routes.MovementDetailsController.saveMovementDetails(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
-        @components.back_link("/customs-movements/goods-departed")
+        @components.back_link(routes.GoodsDepartedController.displayPage())
 
         @components.error_summary(form.errors)
 

--- a/app/views/goods_departed.scala.html
+++ b/app/views/goods_departed.scala.html
@@ -15,11 +15,11 @@
  *@
 
 @import config.AppConfig
-@import controllers.routes._
+@import controllers.routes
 @import forms.GoodsDeparted.AllowedPlaces._
 @import uk.gov.hmrc.play.views.html._
 @import forms.GoodsDeparted
-@import utils.RadioOption
+@import views.components.RadioOption
 
 @this(main_template: views.html.main_template)
 
@@ -29,7 +29,7 @@
     title = messages("goodsDeparted.title"),
     appConfig = appConfig
 ) {
-    @helper.form(GoodsDepartedController.saveGoodsDeparted(), 'autoComplete -> "off") {
+    @helper.form(routes.GoodsDepartedController.saveGoodsDeparted(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
         @components.back_link("/customs-movements/location")

--- a/app/views/goods_departed.scala.html
+++ b/app/views/goods_departed.scala.html
@@ -32,7 +32,7 @@
     @helper.form(routes.GoodsDepartedController.saveGoodsDeparted(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
-        @components.back_link("/customs-movements/location")
+        @components.back_link(routes.LocationController.displayPage())
 
         @components.error_summary(form.errors)
 

--- a/app/views/goods_departed.scala.html
+++ b/app/views/goods_departed.scala.html
@@ -19,7 +19,7 @@
 @import forms.GoodsDeparted.AllowedPlaces._
 @import uk.gov.hmrc.play.views.html._
 @import forms.GoodsDeparted
-@import views.components.RadioOption
+@import views.components.fields.RadioOption
 
 @this(main_template: views.html.main_template)
 

--- a/app/views/location.scala.html
+++ b/app/views/location.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import config.AppConfig
-@import controllers.routes._
+@import controllers.routes
 @import uk.gov.hmrc.play.views.html._
 @import forms.Location
 
@@ -27,7 +27,7 @@
     title = messages("location.title"),
     appConfig = appConfig
 ) {
-    @helper.form(LocationController.saveLocation(), 'autoComplete -> "off") {
+    @helper.form(routes.LocationController.saveLocation(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
         @if(choice == "EAL") {

--- a/app/views/location.scala.html
+++ b/app/views/location.scala.html
@@ -31,9 +31,9 @@
         @helper.CSRF.formField
 
         @if(choice == "EAL") {
-            @components.back_link("/customs-movements/movement-details")
+            @components.back_link(routes.MovementDetailsController.displayPage())
         } else {
-            @components.back_link("/customs-movements/consignment-references")
+            @components.back_link(routes.ConsignmentReferencesController.displayPage())
         }
 
         @components.error_summary(form.errors)

--- a/app/views/start_page.scala.html
+++ b/app/views/start_page.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import config.AppConfig
-@import controllers.routes._
+@import controllers.routes
 
 @this(main_template: views.html.main_template)
 
@@ -41,7 +41,7 @@
                 <li><a href="https://www.gov.uk/government/publications/uk-trade-tariff-customs-procedure-codes/customs-procedure-codes-box-37" target="_blank" rel="noopener noreferrer">@messages("startPage.listItemSevenUrl")</a> @messages("startPage.listItemSeven")</li>
             </ul>
 
-            <p><a class="button button-start" href="@ChoiceController.displayChoiceForm" role="button">@messages("startPage.buttonName")</a></p>
+            <p><a class="button button-start" href="@routes.ChoiceController.displayChoiceForm" role="button">@messages("startPage.buttonName")</a></p>
 
             <p>@messages("startPage.additionalInformation")</p>
 

--- a/app/views/summary/arrival_summary_page.scala.html
+++ b/app/views/summary/arrival_summary_page.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import config.AppConfig
-@import controllers.routes._
+@import controllers.routes
 @import uk.gov.hmrc.http.cache.client.CacheMap
 @import models.viewmodels.HtmlTableRow
 @import forms._
@@ -42,10 +42,12 @@
         @components.table_row_no_change_link(HtmlTableRow(
             label = messages("summary.referenceType"),
             value = data.getEntry[ConsignmentReferences](ConsignmentReferences.formId).map(ref =>
-                ref.reference.equals(AllowedReferences.Ducr) match {
-                    case true => messages("consignmentReferences.reference.ducr")
-                    case _ => messages("consignmentReferences.reference.mucr")
-            })
+                if(ref.reference.equals(AllowedReferences.Ducr)) {
+                    messages("consignmentReferences.reference.ducr")
+                } else {
+                    messages("consignmentReferences.reference.mucr")
+                }
+            )
         ))
         @components.table_row_no_change_link(HtmlTableRow(
             label = messages("summary.referenceValue"),
@@ -82,7 +84,7 @@
         ))
     }
 
-    @helper.form(action = SummaryController.submitMovementRequest()) {
+    @helper.form(action = routes.SummaryController.submitMovementRequest()) {
         @helper.CSRF.formField
 
         @components.submit_button(messages("site.acceptAndSend"))

--- a/app/views/summary/arrival_summary_page.scala.html
+++ b/app/views/summary/arrival_summary_page.scala.html
@@ -30,7 +30,7 @@
     title = messages("summary.title"),
     appConfig = appConfig
 ) {
-    @components.back_link("/customs-movements/transport")
+    @components.back_link(routes.TransportController.displayPage())
 
     @components.page_title(Some("summary.arrival.title"))
 

--- a/app/views/summary/departure_summary_page.scala.html
+++ b/app/views/summary/departure_summary_page.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import config.AppConfig
-@import controllers.routes._
+@import controllers.routes
 @import uk.gov.hmrc.http.cache.client.CacheMap
 @import models.viewmodels.HtmlTableRow
 @import forms._
@@ -32,7 +32,7 @@
         appConfig = appConfig
     ) {
 
-        @if(data.getEntry[GoodsDeparted](GoodsDeparted.formId).map(_.departedPlace) == Some(GoodsDeparted.AllowedPlaces.outOfTheUk)){
+        @if(data.getEntry[GoodsDeparted](GoodsDeparted.formId).map(_.departedPlace).contains(GoodsDeparted.AllowedPlaces.outOfTheUk)){
             @components.back_link("/customs-movements/transport")
         } else {
             @components.back_link("/customs-movements/goods-departed")
@@ -48,10 +48,12 @@
             @components.table_row_no_change_link(HtmlTableRow(
                 label = messages("summary.referenceType"),
                 value = data.getEntry[ConsignmentReferences](ConsignmentReferences.formId).map(ref =>
-                    ref.reference.equals(AllowedReferences.Ducr) match {
-                    case true => messages("consignmentReferences.reference.ducr")
-                    case _ => messages("consignmentReferences.reference.mucr")
-                })
+                    if(ref.reference.equals(AllowedReferences.Ducr)) {
+                        messages("consignmentReferences.reference.ducr")
+                    } else {
+                        messages("consignmentReferences.reference.mucr")
+                    }
+                )
             ))
             @components.table_row_no_change_link(HtmlTableRow(
                 label = messages("summary.referenceValue"),
@@ -73,7 +75,7 @@
             ))
         }
 
-        @if(data.getEntry[GoodsDeparted](GoodsDeparted.formId).map(_.departedPlace) == Some(GoodsDeparted.AllowedPlaces.outOfTheUk)) {
+        @if(data.getEntry[GoodsDeparted](GoodsDeparted.formId).map(_.departedPlace).contains(GoodsDeparted.AllowedPlaces.outOfTheUk)) {
             @components.summary_list(Some(messages("departureDetails.title"))) {
                 @components.table_row_no_change_link(HtmlTableRow(
                     label = messages("summary.departure.date"),
@@ -92,7 +94,7 @@
             }
         }
 
-        @helper.form(action = SummaryController.submitMovementRequest()) {
+        @helper.form(action = routes.SummaryController.submitMovementRequest()) {
             @helper.CSRF.formField
 
             @components.submit_button(messages("site.acceptAndSend"))

--- a/app/views/summary/departure_summary_page.scala.html
+++ b/app/views/summary/departure_summary_page.scala.html
@@ -33,9 +33,9 @@
     ) {
 
         @if(data.getEntry[GoodsDeparted](GoodsDeparted.formId).map(_.departedPlace).contains(GoodsDeparted.AllowedPlaces.outOfTheUk)){
-            @components.back_link("/customs-movements/transport")
+            @components.back_link(routes.TransportController.displayPage())
         } else {
-            @components.back_link("/customs-movements/goods-departed")
+            @components.back_link(routes.GoodsDepartedController.displayPage())
         }
 
         @components.page_title(Some("summary.departure.title"))

--- a/app/views/transport.scala.html
+++ b/app/views/transport.scala.html
@@ -15,11 +15,11 @@
  *@
 
 @import config.AppConfig
-@import controllers.routes._
+@import controllers.routes
 @import uk.gov.hmrc.play.views.html._
 @import forms.Transport
 @import forms.Transport.ModesOfTransport._
-@import utils.RadioOption
+@import views.components.RadioOption
 
 @this(main_template: views.html.main_template)
 
@@ -29,7 +29,7 @@
     title = messages("transport.title"),
     appConfig = appConfig
 ) {
-    @helper.form(TransportController.saveTransport(), 'autoComplete -> "off") {
+    @helper.form(routes.TransportController.saveTransport(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
         @if(choice == "EAL") {

--- a/app/views/transport.scala.html
+++ b/app/views/transport.scala.html
@@ -33,9 +33,9 @@
         @helper.CSRF.formField
 
         @if(choice == "EAL") {
-            @components.back_link("/customs-movements/location")
+            @components.back_link(routes.LocationController.displayPage())
         } else {
-            @components.back_link("/customs-movements/movement-details")
+            @components.back_link(routes.MovementDetailsController.displayPage())
         }
 
         @components.error_summary(form.errors)

--- a/app/views/transport.scala.html
+++ b/app/views/transport.scala.html
@@ -19,7 +19,7 @@
 @import uk.gov.hmrc.play.views.html._
 @import forms.Transport
 @import forms.Transport.ModesOfTransport._
-@import views.components.RadioOption
+@import views.components.fields.RadioOption
 
 @this(main_template: views.html.main_template)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import com.typesafe.sbt.digest.Import._
 import com.typesafe.sbt.uglify.Import._
 import com.typesafe.sbt.web.Import._
 import net.ground5hark.sbt.concat.Import._
-import play.sbt.routes._
 import sbt.Keys._
 import sbt._
 import uk.gov.hmrc.DefaultBuildSettings._
@@ -11,6 +10,8 @@ import uk.gov.hmrc.versioning.SbtGitVersioning
 import uk.gov.hmrc.{SbtArtifactory, SbtAutoBuildPlugin}
 
 val appName = "customs-movements-frontend"
+
+PlayKeys.devSettings := Seq("play.server.http.port" -> "6796")
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory, SbtWeb)

--- a/test/utils/RadioOptionSpec.scala
+++ b/test/utils/RadioOptionSpec.scala
@@ -16,7 +16,7 @@
 
 package utils
 import org.scalatest.{MustMatchers, WordSpec}
-import views.components.RadioOption
+import views.components.fields.RadioOption
 
 class RadioOptionSpec extends WordSpec with MustMatchers {
 

--- a/test/utils/RadioOptionSpec.scala
+++ b/test/utils/RadioOptionSpec.scala
@@ -16,6 +16,7 @@
 
 package utils
 import org.scalatest.{MustMatchers, WordSpec}
+import views.components.RadioOption
 
 class RadioOptionSpec extends WordSpec with MustMatchers {
 

--- a/test/views/ChoiceViewSpec.scala
+++ b/test/views/ChoiceViewSpec.scala
@@ -80,7 +80,7 @@ class ChoiceViewSpec extends ViewSpec with ChoiceMessages with CommonMessages {
       val backButton = getElementById(createView(), "link-back")
 
       backButton.text() must be(messages(backCaption))
-      backButton.attr("href") must be("start")
+      backButton.attr("href") must be(controllers.routes.StartController.displayStartPage().url)
     }
 
     "display \"Save and continue\" button on page" in {


### PR DESCRIPTION
IntelliJ struggles to render templates properly when there are two packages/classes imported with the same name.

For example twirl imports a `utils` package by default (part of Play). If we then import our own `utils` package the template compiles, but IntelliJ gives a tonne of errors. 

Given the fix was quick and easy I figured it was worth doing