### PR TITLE
CEDS-1072 Rename the submissions to movements

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -65,7 +65,7 @@ class AppConfig @Inject()(
   )
 
   lazy val fetchSubmissions = servicesConfig.getConfString(
-    "customs-declare-exports.fetch-submissions",
+    "customs-declare-exports.fetch-movements",
     throw new IllegalStateException("Missing configuration for Customs Declaration Exports fetch submission URI")
   )
 

--- a/app/connectors/CustomsDeclareExportsMovementsConnector.scala
+++ b/app/connectors/CustomsDeclareExportsMovementsConnector.scala
@@ -18,7 +18,7 @@ package connectors
 
 import config.AppConfig
 import javax.inject.{Inject, Singleton}
-import models.{Notification, Submission}
+import models.{Notification, Movement}
 import play.api.Logger
 import play.api.http.{ContentTypes, HeaderNames}
 import play.api.mvc.Codec
@@ -61,8 +61,8 @@ class CustomsDeclareExportsMovementsConnector @Inject()(appConfig: AppConfig, ht
       s"${appConfig.customsDeclareExportsMovements}${appConfig.fetchNotifications}/$conversationId"
     )
 
-  def fetchSubmissions()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[Submission]] =
-    httpClient.GET[Seq[Submission]](s"${appConfig.customsDeclareExportsMovements}${appConfig.fetchSubmissions}").map {
+  def fetchSubmissions()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[Movement]] =
+    httpClient.GET[Seq[Movement]](s"${appConfig.customsDeclareExportsMovements}${appConfig.fetchSubmissions}").map {
       response =>
         logger.debug(s"CUSTOMS_MOVEMENTS_FRONTEND fetch submission response is --> ${response.toString}")
         response

--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -62,7 +62,7 @@ class ChoiceController @Inject()(
                 case DisassociateDUCR =>
                   Redirect(consolidations.routes.DisassociateDucrController.displayPage())
                 case ShutMucr    => Redirect(consolidations.routes.ShutMucrController.displayPage())
-                case Submissions => Redirect(controllers.routes.SubmissionsController.displayPage())
+                case Submissions => Redirect(controllers.routes.MovementsController.displayPage())
                 case _           => Redirect(routes.ChoiceController.displayChoiceForm())
               }
           }

--- a/app/controllers/MovementsController.scala
+++ b/app/controllers/MovementsController.scala
@@ -23,24 +23,26 @@ import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-import views.html.submissions
+import views.html.movements
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class SubmissionsController @Inject()(
+class MovementsController @Inject()(
   authenticate: AuthAction,
   connector: CustomsDeclareExportsMovementsConnector,
   mcc: MessagesControllerComponents,
-  submissionsPage: submissions
+  movementsPage: movements
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] = authenticate.async { implicit request =>
     for {
       submissions <- connector.fetchSubmissions()
-      notifications <- Future.sequence(submissions.map(submission => connector.fetchNotifications(submission.conversationId)))
+      notifications <- Future.sequence(
+        submissions.map(submission => connector.fetchNotifications(submission.conversationId))
+      )
       submissionsWithNotifications = submissions.zip(notifications.map(_.sorted.reverse))
 
-    } yield Ok(submissionsPage(submissionsWithNotifications))
+    } yield Ok(movementsPage(submissionsWithNotifications))
   }
 }

--- a/app/models/Movement.scala
+++ b/app/models/Movement.scala
@@ -19,7 +19,7 @@ import java.time.ZonedDateTime
 
 import play.api.libs.json.Json
 
-case class Submission(
+case class Movement(
   conversationId: String,
   ucr: String,
   submissionType: String,
@@ -28,6 +28,6 @@ case class Submission(
   status: Option[String]
 )
 
-object Submission {
-  implicit val formats = Json.format[Submission]
+object Movement {
+  implicit val formats = Json.format[Movement]
 }

--- a/app/views/movements.scala.html
+++ b/app/views/movements.scala.html
@@ -18,11 +18,11 @@
 @import java.time.format.DateTimeFormatter
 
 @import config.AppConfig
-@import models.{Notification, Submission}
+@import models.{Notification, Movement}
 
 @this(main_template: views.html.main_template)
 
-@(submissions: Seq[(Submission, Seq[Notification])])(implicit request: Request[_], appConfig: AppConfig, messages: Messages)
+@(submissions: Seq[(Movement, Seq[Notification])])(implicit request: Request[_], appConfig: AppConfig, messages: Messages)
 
 @main_template(
     title = messages("submissions.title"),

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -64,7 +64,7 @@ POST        /shut-mucr                             controllers.consolidations.Sh
 GET         /shut-mucr-confirmation                controllers.consolidations.ShutMucrConfirmationController.displayPage()
 
 # Submissions page
-GET         /submissions                           controllers.SubmissionsController.displayPage()
+GET         /movements                             controllers.MovementsController.displayPage()
 
 # Notifications page
 GET         /notifications/:conversationId         controllers.NotificationsController.listOfNotifications(conversationId)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -86,7 +86,7 @@ microservice {
       save-movement-uri = "/save-movement-submission"
       submit-consolidation = "/consolidations/submit"
       fetch-notifications = "/notifications"
-      fetch-submissions = "/submissions"
+      fetch-movements = "/movements"
     }
 
     features {

--- a/test/base/MockCustomsExportsMovement.scala
+++ b/test/base/MockCustomsExportsMovement.scala
@@ -17,7 +17,7 @@
 package base
 
 import connectors.CustomsDeclareExportsMovementsConnector
-import models.Submission
+import models.Movement
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
@@ -43,7 +43,7 @@ trait MockCustomsExportsMovement extends MockitoSugar {
         .submitMovementDeclaration(any(), any(), any())(any(), any())
     ).thenReturn(Future.successful(HttpResponse(BAD_REQUEST)))
 
-  def listOfSubmissions(submissions: Seq[Submission]): OngoingStubbing[Future[Seq[Submission]]] =
+  def listOfSubmissions(submissions: Seq[Movement]): OngoingStubbing[Future[Seq[Movement]]] =
     when(mockCustomsExportsMovementConnector.fetchSubmissions()(any(), any()))
       .thenReturn(Future.successful(submissions))
 }

--- a/test/controllers/ChoiceControllerSpec.scala
+++ b/test/controllers/ChoiceControllerSpec.scala
@@ -156,7 +156,7 @@ class ChoiceControllerSpec extends MovementBaseSpec with ViewValidator with Befo
       val result = route(app, postRequest(choiceUri, correctForm)).get
 
       status(result) must be(SEE_OTHER)
-      redirectLocation(result) must be(Some(controllers.routes.SubmissionsController.displayPage().url))
+      redirectLocation(result) must be(Some(controllers.routes.MovementsController.displayPage().url))
     }
   }
 }

--- a/test/controllers/MovementsControllerSpec.scala
+++ b/test/controllers/MovementsControllerSpec.scala
@@ -20,20 +20,20 @@ import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.when
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import views.html.submissions
+import views.html.movements
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class SubmissionsControllerSpec extends MovementBaseSpec with MockCustomsExportsMovement {
+class MovementsControllerSpec extends MovementBaseSpec with MockCustomsExportsMovement {
 
   trait SetUp {
-    val submissionsPage = new submissions(mainTemplate)
+    val movementsPage = new movements(mainTemplate)
 
-    val controller = new SubmissionsController(
+    val controller = new MovementsController(
       mockAuthAction,
       mockCustomsExportsMovementConnector,
       stubMessagesControllerComponents(),
-      submissionsPage
+      movementsPage
     )(minimalAppConfig, ExecutionContext.global)
 
     authorizedUser()

--- a/test/services/MovementServiceSpec.scala
+++ b/test/services/MovementServiceSpec.scala
@@ -37,7 +37,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.xml.{Node, Utility, XML}
 
-class SubmissionServiceSpec extends WordSpec with MustMatchers with MockitoSugar with ScalaFutures {
+class MovementServiceSpec extends WordSpec with MustMatchers with MockitoSugar with ScalaFutures {
 
   implicit val defaultPatience: PatienceConfig =
     PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Millis))

--- a/test/views/MovementsViewSpec.scala
+++ b/test/views/MovementsViewSpec.scala
@@ -20,20 +20,20 @@ import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, ZoneId, ZonedDateTime}
 
 import base.ViewValidator
-import models.{Notification, Submission}
+import models.{Movement, Notification}
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.Html
 import utils.Stubs
-import views.html.submissions
+import views.html.{movements}
 
-class SubmissionsViewSpec extends WordSpec with MustMatchers with Stubs with ViewValidator {
+class MovementsViewSpec extends WordSpec with MustMatchers with Stubs with ViewValidator {
 
   val messages = stubMessages()
-  val page: Html = new submissions(mainTemplate)(Seq.empty)(FakeRequest(), minimalAppConfig, messages)
+  val page: Html = new movements(mainTemplate)(Seq.empty)(FakeRequest(), minimalAppConfig, messages)
 
-  "Submission page" should {
+  "Movements page" should {
 
     "contains title" in {
 
@@ -55,10 +55,10 @@ class SubmissionsViewSpec extends WordSpec with MustMatchers with Stubs with Vie
         LocalDate.parse("2019-10-31", DateTimeFormatter.ofPattern("yyyy-MM-dd")).atStartOfDay(),
         ZoneId.systemDefault()
       )
-      val pageWithData: Html = new submissions(mainTemplate)(
+      val pageWithData: Html = new movements(mainTemplate)(
         Seq(
           (
-            Submission(
+            Movement(
               conversationId = "conversationId",
               ucr = "4444",
               submissionType = "M",


### PR DESCRIPTION
We do not really use that domain language here and we should not bring
submissions to the mix. These are movements.
This also included a fix for the movements backend url.