### PR TITLE
CEDS-1436 Replace Notification model with NotificationPresentationData

### DIFF
--- a/app/connectors/CustomsDeclareExportsMovementsConnector.scala
+++ b/app/connectors/CustomsDeclareExportsMovementsConnector.scala
@@ -18,7 +18,7 @@ package connectors
 
 import config.AppConfig
 import javax.inject.{Inject, Singleton}
-import models.{Notification, Movement}
+import models.{Movement, NotificationPresentation}
 import play.api.Logger
 import play.api.http.{ContentTypes, HeaderNames}
 import play.api.mvc.Codec
@@ -56,8 +56,8 @@ class CustomsDeclareExportsMovementsConnector @Inject()(appConfig: AppConfig, ht
 
   def fetchNotifications(
     conversationId: String
-  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[Notification]] =
-    httpClient.GET[Seq[Notification]](
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[NotificationPresentation]] =
+    httpClient.GET[Seq[NotificationPresentation]](
       s"${appConfig.customsDeclareExportsMovements}${appConfig.fetchNotifications}/$conversationId"
     )
 

--- a/app/models/NotificationPresentation.scala
+++ b/app/models/NotificationPresentation.scala
@@ -16,19 +16,22 @@
 
 package models
 
-import java.time.ZonedDateTime
+import java.time.Instant
 
 import play.api.libs.json.Json
 
-case class Movement(
+final case class NotificationPresentation(
+  timestampReceived: Instant = Instant.now(),
   conversationId: String,
-  ucr: String,
-  submissionType: String,
-  submissionAction: String,
-  dateUpdated: ZonedDateTime,
-  status: Option[String]
-)
+  ucrBlocks: Seq[UcrBlock],
+  roe: Option[String],
+  soe: Option[String]
+) extends Ordered[NotificationPresentation] {
 
-object Movement {
-  implicit val formats = Json.format[Movement]
+  override def compare(other: NotificationPresentation): Int =
+    this.timestampReceived.compareTo(other.timestampReceived)
+}
+
+object NotificationPresentation {
+  implicit val format = Json.format[NotificationPresentation]
 }

--- a/app/models/UcrBlock.scala
+++ b/app/models/UcrBlock.scala
@@ -15,16 +15,11 @@
  */
 
 package models
-import java.time.ZonedDateTime
 
 import play.api.libs.json.Json
 
-case class Notification(dateTimeReceived: ZonedDateTime, conversationId: String) extends Ordered[Notification] {
+final case class UcrBlock(ucr: String, ucrType: String)
 
-  def compare(that: Notification): Int =
-    this.dateTimeReceived.compareTo(that.dateTimeReceived)
-}
-
-object Notification {
-  implicit val format = Json.format[Notification]
+object UcrBlock {
+  implicit val format = Json.format[UcrBlock]
 }

--- a/app/views/movements.scala.html
+++ b/app/views/movements.scala.html
@@ -18,11 +18,11 @@
 @import java.time.format.DateTimeFormatter
 
 @import config.AppConfig
-@import models.{Notification, Movement}
+@import models.{Movement, NotificationPresentation}
 
 @this(main_template: views.html.main_template)
 
-@(submissions: Seq[(Movement, Seq[Notification])])(implicit request: Request[_], appConfig: AppConfig, messages: Messages)
+@(submissions: Seq[(Movement, Seq[NotificationPresentation])])(implicit request: Request[_], appConfig: AppConfig, messages: Messages)
 
 @main_template(
     title = messages("submissions.title"),
@@ -49,7 +49,7 @@
                     <td class="table-cell" id="submissionType-@submission.conversationId">@submission.submissionType</td>
                     <td class="table-cell" id="submissionAction-@submission.conversationId">@submission.submissionAction</td>
                     <td class="table-cell" id="dateUpdated-@submission.conversationId">
-                        @{notifications.headOption.map(n => n.dateTimeReceived).map(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault()).format(_))}</td>
+                        @{notifications.headOption.map(_.timestampReceived).map(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault()).format(_))}</td>
                     <td class="table-cell" id="status-@submission.conversationId">@submission.status</td>
                     <td class="table-cell" id="noOfNotifications-@submission.conversationId">
                     @if(notifications.nonEmpty) {

--- a/app/views/notifications.scala.html
+++ b/app/views/notifications.scala.html
@@ -15,11 +15,11 @@
  *@
 
 @import config.AppConfig
-@import models.Notification
+@import models.NotificationPresentation
 
 @this(main_template: views.html.main_template)
 
-@(notifications: Seq[Notification])(implicit request: Request[_], appConfig: AppConfig, messages: Messages)
+@(notifications: Seq[NotificationPresentation])(implicit request: Request[_], appConfig: AppConfig, messages: Messages)
 
 @main_template(
     title = messages("notifications.title"),    

--- a/test/base/testdata/CommonTestData.scala
+++ b/test/base/testdata/CommonTestData.scala
@@ -19,5 +19,6 @@ package base.testdata
 object CommonTestData {
 
   val correctUcr: String = "GB/1UZYBD3XE-1J8MEBF9N6X65B"
+  val conversationId: String = "93feaae9-5043-4569-9fc5-ff04bfea0d97"
 
 }

--- a/test/views/MovementsViewSpec.scala
+++ b/test/views/MovementsViewSpec.scala
@@ -20,13 +20,14 @@ import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, ZoneId, ZonedDateTime}
 
 import base.ViewValidator
-import models.{Movement, Notification}
+import base.testdata.CommonTestData.conversationId
+import models.{Movement, NotificationPresentation, UcrBlock}
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.Html
 import utils.Stubs
-import views.html.{movements}
+import views.html.movements
 
 class MovementsViewSpec extends WordSpec with MustMatchers with Stubs with ViewValidator {
 
@@ -59,24 +60,32 @@ class MovementsViewSpec extends WordSpec with MustMatchers with Stubs with ViewV
         Seq(
           (
             Movement(
-              conversationId = "conversationId",
+              conversationId = conversationId,
               ucr = "4444",
               submissionType = "M",
               submissionAction = "Consolidate",
               dateUpdated = dateTime,
               status = Some("Cleared")
             ),
-            Seq(Notification(dateTimeReceived = dateTime, conversationId = "conversationId"))
+            Seq(
+              NotificationPresentation(
+                timestampReceived = dateTime.toInstant,
+                conversationId = conversationId,
+                ucrBlocks = Seq(UcrBlock(ucr = "4444", ucrType = "M")),
+                roe = None,
+                soe = None
+              )
+            )
           )
         )
       )(FakeRequest(), minimalAppConfig, messages)
 
-      getElementById(pageWithData, "ucr-conversationId").text() must be("4444")
-      getElementById(pageWithData, "submissionType-conversationId").text() must be("M")
-      getElementById(pageWithData, "submissionAction-conversationId").text() must be("Consolidate")
-      getElementById(pageWithData, "dateUpdated-conversationId").text() must be("2019-10-31 00:00")
-      getElementById(pageWithData, "status-conversationId").text() must be("Cleared")
-      getElementById(pageWithData, "noOfNotifications-conversationId").text() must be("1")
+      getElementById(pageWithData, s"ucr-$conversationId").text() must be("4444")
+      getElementById(pageWithData, s"submissionType-$conversationId").text() must be("M")
+      getElementById(pageWithData, s"submissionAction-$conversationId").text() must be("Consolidate")
+      getElementById(pageWithData, s"dateUpdated-$conversationId").text() must be("2019-10-31 00:00")
+      getElementById(pageWithData, s"status-$conversationId").text() must be("Cleared")
+      getElementById(pageWithData, s"noOfNotifications-$conversationId").text() must be("1")
     }
   }
 }


### PR DESCRIPTION
Since this class is used for presentation only, it contains only
presentation-relevant fields. Backend should send Notification data
in the same format, decoupling presentation model from DB model.