### PR TITLE
CEDS-1419 - clear the un-used MUCR when validating the form

### DIFF
--- a/app/forms/MucrOptions.scala
+++ b/app/forms/MucrOptions.scala
@@ -21,7 +21,12 @@ import play.api.data.{Form, Forms}
 import play.api.libs.json.Json
 import utils.validators.forms.FieldValidator._
 
-case class MucrOptions(mucr: String, createOrAdd: String = MucrOptions.Create)
+case class MucrOptions(newMucr: String = "", existingMucr: String = "", createOrAdd: String = MucrOptions.Create) {
+  def mucr: String = createOrAdd match {
+    case MucrOptions.Create => newMucr
+    case MucrOptions.Add => existingMucr
+  }
+}
 
 object MucrOptions {
 
@@ -35,12 +40,12 @@ object MucrOptions {
   def form2Model: (String, String, String) => MucrOptions = {
     case (createOrAdd, newMucr, existingMucr) =>
       createOrAdd match {
-        case Create => MucrOptions(newMucr, Create)
-        case Add => MucrOptions(existingMucr, Add)
+        case Create => MucrOptions(newMucr, "",  Create)
+        case Add => MucrOptions("", existingMucr, Add)
       }
   }
 
-  def model2Form: MucrOptions => Option[(String, String, String)] = m => Some((m.createOrAdd, m.mucr, m.mucr))
+  def model2Form: MucrOptions => Option[(String, String, String)] = m => Some((m.createOrAdd, m.newMucr, m.existingMucr))
 
   val mapping =
     Forms

--- a/test/controllers/consolidations/MucrOptionsControllerSpec.scala
+++ b/test/controllers/consolidations/MucrOptionsControllerSpec.scala
@@ -103,6 +103,30 @@ class MucrOptionsControllerSpec extends MovementBaseSpec with ViewValidator with
       page must haveFieldError("newMucr", "Please enter a valid reference")
     }
 
+    "clear value of exisiting MUCR after validation failure" in {
+      val invalidMUCR =
+        JsObject(Map("createOrAdd" -> JsString(Create), "newMucr" -> JsString("invalidNew"), "existingMucr" -> JsString("invalidExisting")))
+      val Some(result) = route(app, postRequest(uri, invalidMUCR))
+
+      status(result) must be(BAD_REQUEST)
+      val page = htmlBodyOf(result)
+
+      page.getElementById("newMucr") must haveAttribute("value", "invalidNew")
+      page.getElementById("existingMucr") must haveAttribute("value", "")
+    }
+
+    "clear value of new MUCR after validation failure" in {
+      val invalidMUCR =
+        JsObject(Map("createOrAdd" -> JsString(Add), "newMucr" -> JsString("invalidNew"), "existingMucr" -> JsString("invalidExisting")))
+      val Some(result) = route(app, postRequest(uri, invalidMUCR))
+
+      status(result) must be(BAD_REQUEST)
+      val page = htmlBodyOf(result)
+
+      page.getElementById("newMucr") must haveAttribute("value", "")
+      page.getElementById("existingMucr") must haveAttribute("value", "invalidExisting")
+    }
+
     "display an error for an invalid existing MUCR" in {
       val invalidMUCR = JsObject(Map("createOrAdd" -> JsString(Add), "newMucr" -> JsString(""), "existingMucr" -> JsString("invalid")))
       val Some(result) = route(app, postRequest(uri, invalidMUCR))
@@ -122,7 +146,7 @@ class MucrOptionsControllerSpec extends MovementBaseSpec with ViewValidator with
       redirectLocation(result) mustBe Some(routes.AssociateDucrController.displayPage().url)
 
       theFormIDCached mustBe MucrOptions.formId
-      theDataCached mustBe MucrOptions("8GB12345612345612345", Create)
+      theDataCached mustBe MucrOptions(newMucr = "8GB12345612345612345", createOrAdd = Create)
     }
 
     "Redirect to next page for a valid existing MUCR" in {
@@ -133,7 +157,7 @@ class MucrOptionsControllerSpec extends MovementBaseSpec with ViewValidator with
       redirectLocation(result) mustBe Some(routes.AssociateDucrController.displayPage().url)
 
       theFormIDCached mustBe MucrOptions.formId
-      theDataCached mustBe MucrOptions("8GB12345612345612345", Add)
+      theDataCached mustBe MucrOptions(existingMucr = "8GB12345612345612345", createOrAdd = Add)
     }
 
   }


### PR DESCRIPTION
Change to clear the value of the MUCR not being used when the form fails validation.   Previously we only captured one MUCR value (for either create or add).  If the user entered an invalid value into both fields and submitted the page they got an error highlighting the MUCR field that was wrong.  But if they when switched to the other MUCR field, that was populated with the 'other' MUCR value (i.e. not the one submitted).

We now clear (remove) the 'hidden' MUCR value on submission.   The other option was to leave the hidden MUCR value un-touched but as that MUCR may have been valid it was thought that this might confuse the users even more.