### PR TITLE
CEDS-1581 Add ip whitelist for service

### DIFF
--- a/app/filters/Filters.scala
+++ b/app/filters/Filters.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import javax.inject.Inject
+import play.api.http.HttpFilters
+import play.api.mvc.EssentialFilter
+import uk.gov.hmrc.play.bootstrap.filters.FrontendFilters
+
+class Filters @Inject()(platform: FrontendFilters, whitelist: WhitelistIpFilter) extends HttpFilters {
+  override val filters: Seq[EssentialFilter] = platform.filters :+ whitelist
+}

--- a/app/filters/WhitelistIpFilter.scala
+++ b/app/filters/WhitelistIpFilter.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.whitelist.AkamaiWhitelistFilter
 import scala.concurrent.Future
 
 @ProvidedBy(classOf[WhitelistIpFilterProvider])
-class WhitelistIpFilter (
+class WhitelistIpFilter(
   val enabled: Boolean,
   val excludeList: Seq[String],
   override val whitelist: Seq[String],
@@ -35,19 +35,18 @@ class WhitelistIpFilter (
 
   override val destination: Call = Call("GET", "https://www.gov.uk")
 
-
   override val excludedPaths: Seq[Call] = excludeList.map(Call("GET", _))
 
-  override def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
-    if(enabled) {
+  override def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] =
+    if (enabled) {
       super.apply(f)(rh)
     } else {
       f(rh)
     }
-  }
 }
 
-class WhitelistIpFilterProvider @Inject()(configuration: Configuration, materializer: Materializer) extends Provider[WhitelistIpFilter] {
+class WhitelistIpFilterProvider @Inject()(configuration: Configuration, materializer: Materializer)
+    extends Provider[WhitelistIpFilter] {
   override def get(): WhitelistIpFilter = {
     val whitelistConfig = configuration.get[Configuration]("ip-whitelist")
     val enabled = whitelistConfig.get[Boolean]("enabled")

--- a/app/filters/WhitelistIpFilter.scala
+++ b/app/filters/WhitelistIpFilter.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import akka.stream.Materializer
+import com.google.inject.{ProvidedBy, Provider}
+import javax.inject.Inject
+import play.api.Configuration
+import play.api.mvc.{Call, RequestHeader, Result}
+import uk.gov.hmrc.whitelist.AkamaiWhitelistFilter
+
+import scala.concurrent.Future
+
+@ProvidedBy(classOf[WhitelistIpFilterProvider])
+class WhitelistIpFilter (
+  val enabled: Boolean,
+  val excludeList: Seq[String],
+  override val whitelist: Seq[String],
+  override val mat: Materializer
+) extends AkamaiWhitelistFilter {
+
+  override val destination: Call = Call("GET", "https://www.gov.uk")
+
+
+  override val excludedPaths: Seq[Call] = excludeList.map(Call("GET", _))
+
+  override def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
+    if(enabled) {
+      super.apply(f)(rh)
+    } else {
+      f(rh)
+    }
+  }
+}
+
+class WhitelistIpFilterProvider @Inject()(configuration: Configuration, materializer: Materializer) extends Provider[WhitelistIpFilter] {
+  override def get(): WhitelistIpFilter = {
+    val whitelistConfig = configuration.get[Configuration]("ip-whitelist")
+    val enabled = whitelistConfig.get[Boolean]("enabled")
+    val exclude = whitelistConfig.get[Seq[String]]("exclude")
+    val list = whitelistConfig.get[Seq[String]]("list")
+    new WhitelistIpFilter(enabled, exclude, list, materializer)
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -32,7 +32,7 @@ play.filters.csrf.contentType.whiteList = ["application/xml", "application/json"
 
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 play.http.errorHandler = "handlers.ErrorHandler"
-play.http.filters = "uk.gov.hmrc.play.bootstrap.filters.FrontendFilters"
+play.http.filters = "filters.Filters"
 # Play Modules
 # ~~~~
 # Additional play modules can be added here
@@ -130,6 +130,12 @@ auditing {
       port = 8100
     }
   }
+}
+
+ip-whitelist {
+  enabled: false
+  list: ["127.0.0.1"]
+  exclude: ["/ping/ping", "/healthcheck"]
 }
 
 google-analytics {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -16,6 +16,7 @@ object AppDependencies {
     "uk.gov.hmrc" %% "bootstrap-play-26" % "0.45.0",
     "uk.gov.hmrc" %% "wco-dec" % "0.31.0",
     "uk.gov.hmrc" %% "play-language" % "4.1.0",
+    "uk.gov.hmrc" %% "play-whitelist-filter" % "3.1.0-play-26",
     "ai.x"         %% "play-json-extensions" % "0.40.2"
   )
 

--- a/test/filters/ApplicationFiltersIntegrationTest.scala
+++ b/test/filters/ApplicationFiltersIntegrationTest.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.http.HttpFilters
+
+class ApplicationFiltersIntegrationTest extends WordSpec with GuiceOneAppPerSuite with MustMatchers {
+
+  "Application filter" should {
+    "contains whitespace filter" in {
+      atLeast(1, app.injector.instanceOf[HttpFilters].filters) mustBe a[WhitelistIpFilter]
+    }
+  }
+
+}

--- a/test/filters/WhitelistIPFilterProviderSpec.scala
+++ b/test/filters/WhitelistIPFilterProviderSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.Configuration
+import play.api.test.NoMaterializer
+
+class WhitelistIPFilterProviderSpec extends WordSpec with MustMatchers {
+
+  val configuration = Configuration(
+    "ip-whitelist.enabled" -> "true",
+    "ip-whitelist.list.0" -> "127.0.0.1",
+    "ip-whitelist.exclude.0" -> "/healthcheck",
+    "ip-whitelist.exclude.1" -> "/ping/ping"
+  )
+
+  val provider = new WhitelistIpFilterProvider(configuration, NoMaterializer)
+
+  "WhitelistIPFilter Provider" should {
+    "load ip whitelist from configuration key" in {
+      val filter = provider.get()
+      filter.enabled mustBe true
+      filter.whitelist mustEqual Seq("127.0.0.1")
+      filter.excludeList must contain("/healthcheck")
+      filter.excludeList must contain("/ping/ping")
+    }
+  }
+
+}


### PR DESCRIPTION
Use same aproch like in customs-declare-exports-frontend.
/healthcheck and /ping/ping must be excluded for docktor checks