### PR TITLE
CEDS-1681 Rename Audit Types

### DIFF
--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -29,7 +29,7 @@ import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import play.api.test.Helpers.ACCEPTED
-import services.audit.AuditService
+import services.audit.{AuditService, AuditTypes}
 import testdata.ConsolidationTestData._
 import testdata.MovementsTestData._
 import uk.gov.hmrc.http.cache.client.CacheMap
@@ -97,12 +97,9 @@ class SubmissionServiceSpec
         submissionService.submitMovementRequest("EAL-eori1", "eori1", Choice(Arrival)).futureValue must equal(
           CustomHttpResponseCode
         )
-        verify(mockAuditService).auditMovements(
-          any(),
-          any(),
-          any(),
-          ArgumentMatchers.eq(Choice(Choice.AllowedChoiceValues.Arrival))
-        )(any())
+        verify(mockAuditService).auditMovements(any(), any(), any(), ArgumentMatchers.eq(AuditTypes.AuditArrival))(
+          any()
+        )
         verify(mockAuditService)
           .auditAllPagesUserInput(ArgumentMatchers.eq(Choice(Choice.AllowedChoiceValues.Arrival)), any())(any())
       }
@@ -115,12 +112,9 @@ class SubmissionServiceSpec
         submissionService.submitMovementRequest("EAL-eori1", "eori1", Choice(Arrival)).futureValue
 
         verify(customsExportsMovementConnectorMock).sendArrivalDeclaration(any())(any(), any())
-        verify(mockAuditService).auditMovements(
-          any(),
-          any(),
-          any(),
-          ArgumentMatchers.eq(Choice(Choice.AllowedChoiceValues.Arrival))
-        )(any())
+        verify(mockAuditService).auditMovements(any(), any(), any(), ArgumentMatchers.eq(AuditTypes.AuditArrival))(
+          any()
+        )
         verify(mockAuditService)
           .auditAllPagesUserInput(ArgumentMatchers.eq(Choice(Choice.AllowedChoiceValues.Arrival)), any())(any())
       }
@@ -150,12 +144,9 @@ class SubmissionServiceSpec
         submissionService.submitMovementRequest("EDL-eori1", "eori1", Choice(Departure)).futureValue must equal(
           CustomHttpResponseCode
         )
-        verify(mockAuditService).auditMovements(
-          any(),
-          any(),
-          any(),
-          ArgumentMatchers.eq(Choice(Choice.AllowedChoiceValues.Departure))
-        )(any())
+        verify(mockAuditService).auditMovements(any(), any(), any(), ArgumentMatchers.eq(AuditTypes.AuditDeparture))(
+          any()
+        )
         verify(mockAuditService)
           .auditAllPagesUserInput(ArgumentMatchers.eq(Choice(Choice.AllowedChoiceValues.Departure)), any())(any())
       }
@@ -168,12 +159,9 @@ class SubmissionServiceSpec
         submissionService.submitMovementRequest("EDL-eori1", "eori1", Choice(Departure)).futureValue
 
         verify(customsExportsMovementConnectorMock).sendDepartureDeclaration(any())(any(), any())
-        verify(mockAuditService).auditMovements(
-          any(),
-          any(),
-          any(),
-          ArgumentMatchers.eq(Choice(Choice.AllowedChoiceValues.Departure))
-        )(any())
+        verify(mockAuditService).auditMovements(any(), any(), any(), ArgumentMatchers.eq(AuditTypes.AuditDeparture))(
+          any()
+        )
         verify(mockAuditService)
           .auditAllPagesUserInput(ArgumentMatchers.eq(Choice(Choice.AllowedChoiceValues.Departure)), any())(any())
       }

--- a/test/services/audit/AuditServiceSpec.scala
+++ b/test/services/audit/AuditServiceSpec.scala
@@ -16,7 +16,6 @@
 
 package services.audit
 import base.BaseSpec
-import forms.Choice
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito.{reset, verify, when}
@@ -48,7 +47,7 @@ class AuditServiceSpec extends BaseSpec with BeforeAndAfterEach {
     "audit Shut a Mucr data" in {
       val dataToAudit = Map(EORI.toString -> "eori", MUCR.toString -> "mucr", SubmissionResult.toString -> "200")
       spyAuditService.auditShutMucr("eori", "mucr", "200")
-      verify(spyAuditService).audit(Choice(Choice.AllowedChoiceValues.ShutMucr), dataToAudit)
+      verify(spyAuditService).audit(AuditTypes.AuditShutMucr, dataToAudit)
     }
 
     "audit an association" in {
@@ -59,13 +58,13 @@ class AuditServiceSpec extends BaseSpec with BeforeAndAfterEach {
         SubmissionResult.toString -> "200"
       )
       spyAuditService.auditAssociate("eori", "mucr", "ducr", "200")
-      verify(spyAuditService).audit(Choice(Choice.AllowedChoiceValues.AssociateDUCR), dataToAudit)
+      verify(spyAuditService).audit(AuditTypes.AuditAssociate, dataToAudit)
     }
 
     "audit a disassociation" in {
       val dataToAudit = Map(EORI.toString -> "eori", DUCR.toString -> "ducr", SubmissionResult.toString -> "200")
       spyAuditService.auditDisassociate("eori", "ducr", "200")
-      verify(spyAuditService).audit(Choice(Choice.AllowedChoiceValues.DisassociateDUCR), dataToAudit)
+      verify(spyAuditService).audit(AuditTypes.AuditDisassociate, dataToAudit)
     }
 
     "audit a movement" in {
@@ -79,8 +78,8 @@ class AuditServiceSpec extends BaseSpec with BeforeAndAfterEach {
       )
       val data =
         InventoryLinkingMovementRequest(messageCode = "EAD", ucrBlock = UcrBlock("UCR", "D"), goodsLocation = "")
-      spyAuditService.auditMovements("eori", data, "200", Choice(Choice.AllowedChoiceValues.Arrival))
-      verify(spyAuditService).audit(Choice(Choice.AllowedChoiceValues.Arrival), dataToAudit)
+      spyAuditService.auditMovements("eori", data, "200", AuditTypes.AuditArrival)
+      verify(spyAuditService).audit(AuditTypes.AuditArrival, dataToAudit)
     }
   }
 }


### PR DESCRIPTION
Instead of having the DMS movement keys, we will use the human readable
version:

Arrival
Departure
Associate
Disassociate
ShutMucr

This fix also impacts CEDS-1683 and CEDS-1684