### PR TITLE
CEDS-1660 Audit Movements in Json format

### DIFF
--- a/app/forms/DepartureDetails.scala
+++ b/app/forms/DepartureDetails.scala
@@ -18,7 +18,7 @@ package forms
 
 import forms.common.Date
 import play.api.data.Forms
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class DepartureDetails(dateOfDeparture: Date) {
 
@@ -26,7 +26,7 @@ case class DepartureDetails(dateOfDeparture: Date) {
 }
 
 object DepartureDetails {
-  implicit val format = Json.format[DepartureDetails]
+  implicit val format: OFormat[DepartureDetails] = Json.format[DepartureDetails]
 
   val mapping =
     Forms.mapping("dateOfDeparture" -> Date.mapping)(DepartureDetails.apply)(DepartureDetails.unapply)

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -23,7 +23,6 @@ import javax.inject.{Inject, Singleton}
 import metrics.MovementsMetrics
 import models.external.requests.InventoryLinkingConsolidationRequestFactory._
 import play.api.http.Status.INTERNAL_SERVER_ERROR
-import play.api.libs.json.{JsObject, Json}
 import services.audit.{AuditService, AuditTypes}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.wco.dec.inventorylinking.movement.request.InventoryLinkingMovementRequest
@@ -48,7 +47,7 @@ class SubmissionService @Inject()(
         val data = Movement.createMovementRequest(cacheMap, eori, choice)
         val timer = metrics.startTimer(choice.value)
 
-        auditService.auditAllPagesUserInput(choice, Json.toJson(cacheMap).as[JsObject])
+        auditService.auditAllPagesUserInput(choice, cacheMap)
 
         val movementAuditType =
           if (choice.value == Choice.AllowedChoiceValues.Arrival) AuditTypes.AuditArrival else AuditTypes.AuditDeparture

--- a/test/services/audit/AuditServiceSpec.scala
+++ b/test/services/audit/AuditServiceSpec.scala
@@ -15,21 +15,24 @@
  */
 
 package services.audit
-import base.BaseSpec
+import base.{BaseSpec, MockCustomsCacheService}
+import forms._
+import forms.common.{Date, Time}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito.{reset, verify, when}
 import org.scalatest.BeforeAndAfterEach
-import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.libs.json.Json
 import services.audit.EventData._
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import uk.gov.hmrc.wco.dec.inventorylinking.common.UcrBlock
 import uk.gov.hmrc.wco.dec.inventorylinking.movement.request.InventoryLinkingMovementRequest
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AuditServiceSpec extends BaseSpec with BeforeAndAfterEach {
+class AuditServiceSpec extends BaseSpec with BeforeAndAfterEach with MockCustomsCacheService {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
   implicit val headerCarrier = HeaderCarrier()
@@ -65,6 +68,28 @@ class AuditServiceSpec extends BaseSpec with BeforeAndAfterEach {
       val dataToAudit = Map(EORI.toString -> "eori", DUCR.toString -> "ducr", SubmissionResult.toString -> "200")
       spyAuditService.auditDisassociate("eori", "ducr", "200")
       verify(spyAuditService).audit(AuditTypes.AuditDisassociate, dataToAudit)
+    }
+
+    "get movements data in a Json format" in {
+
+      val expectedResult = Map(
+        Location.formId -> Json.toJson(Location("A", "U", "correct", "PL")),
+        MovementDetails.formId -> Json.toJson(
+          ArrivalDetails(
+            dateOfArrival = Date(Some(12), Some(1), Some(2019)),
+            timeOfArrival = Time(Some("10"), Some("10"))
+          )
+        ),
+        ArrivalReference.formId -> Json.toJson(ArrivalReference(Some("213"))),
+        GoodsDeparted.formId -> Json.toJson(GoodsDeparted("Bricks")),
+        ConsignmentReferences.formId -> Json.toJson(ConsignmentReferences("reference", "value")),
+        Transport.formId -> Json.toJson(Transport("1", "GB"))
+      )
+
+      val cacheMap = CacheMap(id = "CacheID", data = expectedResult)
+      spyAuditService.getMovementsData(Choice(Choice.AllowedChoiceValues.Arrival), cacheMap) mustBe Json.toJson(
+        expectedResult
+      )
     }
 
     "audit a movement" in {


### PR DESCRIPTION
Keystore which is the tech underlying the CacheMap encrypts the data, so
we need to get each entry and then transform it into Json.
This is another reason for us to move away from Keystore