### PR TITLE
CEDS-1860 Improve algorithm in ViewSubmissionsController

### DIFF
--- a/app/connectors/CustomsDeclareExportsMovementsConnector.scala
+++ b/app/connectors/CustomsDeclareExportsMovementsConnector.scala
@@ -84,6 +84,14 @@ class CustomsDeclareExportsMovementsConnector @Inject()(appConfig: AppConfig, ht
         case Failure(exception) => logger.warn(s"Notifications fetch failure. $exception")
       }
 
+  def fetchAllNotificationsForUser(eori: String)(implicit hc: HeaderCarrier): Future[Seq[NotificationFrontendModel]] =
+    httpClient
+      .GET[Seq[NotificationFrontendModel]](s"${appConfig.customsDeclareExportsMovements}${appConfig.fetchNotifications}", eoriQueryParam(eori))
+      .andThen {
+        case Success(response)  => logger.debug(s"Notifications fetch response. $response")
+        case Failure(exception) => logger.warn(s"Notifications fetch failure. $exception")
+      }
+
   def fetchAllSubmissions(eori: String)(implicit hc: HeaderCarrier): Future[Seq[SubmissionFrontendModel]] =
     httpClient
       .GET[Seq[SubmissionFrontendModel]](s"${appConfig.customsDeclareExportsMovements}${appConfig.fetchAllSubmissions}", eoriQueryParam(eori))

--- a/app/controllers/MovementsController.scala
+++ b/app/controllers/MovementsController.scala
@@ -28,7 +28,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.movements
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class MovementsController @Inject()(
   authenticate: AuthAction,
@@ -38,18 +38,30 @@ class MovementsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
-  private def sort(submissionsWithNotifications: Seq[(SubmissionFrontendModel, Seq[NotificationFrontendModel])]) =
-    submissionsWithNotifications.sortBy(_._1.requestTimestamp)(Ordering[Instant].reverse)
-
   def displayPage(): Action[AnyContent] = authenticate.async { implicit request =>
     val eori = request.user.eori
 
     for {
       submissions <- connector.fetchAllSubmissions(eori)
-      notifications <- Future.sequence(submissions.map(submission => connector.fetchNotifications(submission.conversationId, eori)))
-      submissionsWithNotifications = submissions.zip(notifications.map(_.sorted.reverse))
-
-    } yield Ok(movementsPage(sort(submissionsWithNotifications)))
+      notifications <- connector.fetchAllNotificationsForUser(eori)
+      submissionsWithNotifications = matchNotificationsAgainstSubmissions(submissions, notifications)
+    } yield Ok(movementsPage(sortWithOldestLast(submissionsWithNotifications)))
   }
+
+  private def matchNotificationsAgainstSubmissions(
+    submissions: Seq[SubmissionFrontendModel],
+    notifications: Seq[NotificationFrontendModel]
+  ): Seq[(SubmissionFrontendModel, Seq[NotificationFrontendModel])] = {
+    val groupedNotifications: Map[String, Seq[NotificationFrontendModel]] = notifications.groupBy(_.conversationId).withDefaultValue(Seq.empty)
+
+    submissions.map { submission =>
+      (submission, groupedNotifications(submission.conversationId))
+    }
+  }
+
+  private def sortWithOldestLast(
+    submissionsWithNotifications: Seq[(SubmissionFrontendModel, Seq[NotificationFrontendModel])]
+  ): Seq[(SubmissionFrontendModel, Seq[NotificationFrontendModel])] =
+    submissionsWithNotifications.sortBy(_._1.requestTimestamp)(Ordering[Instant].reverse)
 
 }

--- a/test/unit/controllers/MovementsControllerSpec.scala
+++ b/test/unit/controllers/MovementsControllerSpec.scala
@@ -23,10 +23,13 @@ import controllers.MovementsController
 import models.notifications.NotificationFrontendModel
 import models.submissions.SubmissionFrontendModel
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.{any, anyString}
+import org.mockito.ArgumentMatchers.{any, anyString, eq => meq}
 import org.mockito.Mockito.{reset, verify, when}
+import org.scalatest.concurrent.ScalaFutures
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
+import testdata.CommonTestData._
+import testdata.MovementsTestData
 import testdata.MovementsTestData.exampleSubmissionFrontendModel
 import testdata.NotificationTestData.exampleNotificationFrontendModel
 import unit.base.ControllerSpec
@@ -35,7 +38,7 @@ import views.html.movements
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.Future
 
-class MovementsControllerSpec extends ControllerSpec with MockCustomsExportsMovement {
+class MovementsControllerSpec extends ControllerSpec with MockCustomsExportsMovement with ScalaFutures {
 
   private val mockMovementsPage = mock[movements]
 
@@ -55,7 +58,87 @@ class MovementsControllerSpec extends ControllerSpec with MockCustomsExportsMove
     super.afterEach()
   }
 
-  "Submissions Controller" should {
+  "Submissions Controller on displayPage" should {
+
+    "return 200 (OK)" in {
+
+      when(mockCustomsExportsMovementConnector.fetchAllSubmissions(any[String])(any())).thenReturn(Future.successful(Seq.empty))
+      when(mockCustomsExportsMovementConnector.fetchAllNotificationsForUser(any[String])(any())).thenReturn(Future.successful(Seq.empty))
+
+      val result = controller.displayPage()(getRequest())
+
+      status(result) mustBe OK
+    }
+
+    "call connector for all Submissions" in {
+
+      when(mockCustomsExportsMovementConnector.fetchAllSubmissions(any[String])(any())).thenReturn(Future.successful(Seq.empty))
+      when(mockCustomsExportsMovementConnector.fetchAllNotificationsForUser(any[String])(any())).thenReturn(Future.successful(Seq.empty))
+
+      controller.displayPage()(getRequest()).futureValue
+
+      val expectedEori = validEori
+      verify(mockCustomsExportsMovementConnector).fetchAllSubmissions(meq(expectedEori))(any())
+    }
+
+    "call connector for all Notifications" in {
+
+      val submission = MovementsTestData.exampleSubmissionFrontendModel()
+      when(mockCustomsExportsMovementConnector.fetchAllSubmissions(any[String])(any())).thenReturn(Future.successful(Seq(submission)))
+      when(mockCustomsExportsMovementConnector.fetchAllNotificationsForUser(any[String])(any())).thenReturn(Future.successful(Seq.empty))
+
+      controller.displayPage()(getRequest()).futureValue
+
+      val expectedEori = validEori
+      verify(mockCustomsExportsMovementConnector).fetchAllNotificationsForUser(meq(expectedEori))(any())
+    }
+
+    "call submissions view, passing Submissions in descending order" when {
+
+      "there are no Notifications for the Submissions" in {
+
+        val submission1 = exampleSubmissionFrontendModel(requestTimestamp = Instant.now().minusSeconds(60))
+        val submission2 = exampleSubmissionFrontendModel(requestTimestamp = Instant.now().minusSeconds(30))
+        val submission3 = exampleSubmissionFrontendModel(requestTimestamp = Instant.now())
+
+        when(mockCustomsExportsMovementConnector.fetchAllSubmissions(any[String])(any()))
+          .thenReturn(Future.successful(Seq(submission1, submission2, submission3)))
+        when(mockCustomsExportsMovementConnector.fetchAllNotificationsForUser(any[String])(any())).thenReturn(Future.successful(Seq.empty))
+
+        controller.displayPage()(getRequest()).futureValue
+
+        val viewArguments: Seq[(SubmissionFrontendModel, Seq[NotificationFrontendModel])] = captureViewArguments()
+
+        val submissions: Seq[SubmissionFrontendModel] = viewArguments.map(_._1)
+        submissions mustBe Seq(submission3, submission2, submission1)
+      }
+
+      "there are Notifications for the Submissions" in {
+
+        val submission1 = exampleSubmissionFrontendModel(conversationId = conversationId, requestTimestamp = Instant.now().minusSeconds(60))
+        val submission2 = exampleSubmissionFrontendModel(conversationId = conversationId_2, requestTimestamp = Instant.now().minusSeconds(30))
+        val submission3 = exampleSubmissionFrontendModel(conversationId = conversationId_3, requestTimestamp = Instant.now())
+
+        val notification1 = exampleNotificationFrontendModel(conversationId = conversationId)
+        val notification2 = exampleNotificationFrontendModel(conversationId = conversationId_2)
+        val notification3 = exampleNotificationFrontendModel(conversationId = conversationId_3)
+        val notification4 = exampleNotificationFrontendModel(conversationId = conversationId_3)
+
+        when(mockCustomsExportsMovementConnector.fetchAllSubmissions(any[String])(any()))
+          .thenReturn(Future.successful(Seq(submission1, submission2, submission3)))
+        when(mockCustomsExportsMovementConnector.fetchAllNotificationsForUser(any[String])(any()))
+          .thenReturn(Future.successful(Seq(notification1, notification2, notification3, notification4)))
+
+        controller.displayPage()(getRequest()).futureValue
+
+        val viewArguments: Seq[(SubmissionFrontendModel, Seq[NotificationFrontendModel])] = captureViewArguments()
+
+        val submissions: Seq[SubmissionFrontendModel] = viewArguments.map(_._1)
+        val notifications: Seq[Seq[NotificationFrontendModel]] = viewArguments.map(_._2)
+        submissions mustBe Seq(submission3, submission2, submission1)
+        notifications mustBe Seq(Seq(notification4, notification3), Seq(notification2), Seq(notification1))
+      }
+    }
 
     "return 200 (OK)" when {
 
@@ -67,7 +150,7 @@ class MovementsControllerSpec extends ControllerSpec with MockCustomsExportsMove
 
         when(mockCustomsExportsMovementConnector.fetchAllSubmissions(anyString())(any()))
           .thenReturn(Future.successful(Seq(submission1, submission2, submission3)))
-        when(mockCustomsExportsMovementConnector.fetchNotifications(anyString(), anyString())(any(), any()))
+        when(mockCustomsExportsMovementConnector.fetchAllNotificationsForUser(anyString())(any()))
           .thenReturn(Future.successful(Seq(exampleNotificationFrontendModel())))
 
         val result = controller.displayPage()(getRequest())
@@ -84,4 +167,12 @@ class MovementsControllerSpec extends ControllerSpec with MockCustomsExportsMove
       }
     }
   }
+
+  private def captureViewArguments(): Seq[(SubmissionFrontendModel, Seq[NotificationFrontendModel])] = {
+    val captor: ArgumentCaptor[Seq[(SubmissionFrontendModel, Seq[NotificationFrontendModel])]] =
+      ArgumentCaptor.forClass(classOf[Seq[(SubmissionFrontendModel, Seq[NotificationFrontendModel])]])
+    verify(mockMovementsPage).apply(captor.capture())(any(), any())
+    captor.getValue
+  }
+
 }


### PR DESCRIPTION
The algorithm is for matching Submissions with Notifications by their
conversation ID.

The time complexity used to be s * n, where:
 - s - number of Submissions
 - n - number of Notifications
For large amounts of those it would get slower quite quickly.
Additionally it was sorting Notifications before the process which was
unnecessary as they were being filtered later.

The new solution makes use of groupBy method and therefore comes down
to logarithmic complexity.