### PR TITLE
CEDS-1940 Align behaviour with Internal UI

### DIFF
--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -50,8 +50,8 @@ class ChoiceController @Inject()(
     customsCacheService.cache[Choice](cacheId, choiceId, correctChoice).map { _ =>
       correctChoice match {
         case Arrival | Departure => Redirect(controllers.routes.ConsignmentReferencesController.displayPage())
-        case AssociateDUCR       => Redirect(controllers.consolidations.routes.MucrOptionsController.displayPage())
-        case DisassociateDUCR    => Redirect(controllers.consolidations.routes.DisassociateUcrController.displayPage())
+        case AssociateUCR       => Redirect(controllers.consolidations.routes.MucrOptionsController.displayPage())
+        case DisassociateUCR    => Redirect(controllers.consolidations.routes.DisassociateUcrController.displayPage())
         case ShutMUCR            => Redirect(controllers.consolidations.routes.ShutMucrController.displayPage())
         case Submissions         => Redirect(controllers.routes.MovementsController.displayPage())
       }
@@ -69,9 +69,9 @@ class ChoiceController @Inject()(
             .map { _ =>
               validChoice match {
                 case Arrival | Departure => Redirect(routes.ConsignmentReferencesController.displayPage())
-                case AssociateDUCR =>
+                case AssociateUCR =>
                   Redirect(consolidations.routes.MucrOptionsController.displayPage())
-                case DisassociateDUCR =>
+                case DisassociateUCR =>
                   Redirect(consolidations.routes.DisassociateUcrController.displayPage())
                 case ShutMUCR    => Redirect(consolidations.routes.ShutMucrController.displayPage())
                 case Submissions => Redirect(controllers.routes.MovementsController.displayPage())

--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -50,8 +50,8 @@ class ChoiceController @Inject()(
     customsCacheService.cache[Choice](cacheId, choiceId, correctChoice).map { _ =>
       correctChoice match {
         case Arrival | Departure => Redirect(controllers.routes.ConsignmentReferencesController.displayPage())
-        case AssociateUCR       => Redirect(controllers.consolidations.routes.MucrOptionsController.displayPage())
-        case DisassociateUCR    => Redirect(controllers.consolidations.routes.DisassociateUcrController.displayPage())
+        case AssociateUCR        => Redirect(controllers.consolidations.routes.MucrOptionsController.displayPage())
+        case DisassociateUCR     => Redirect(controllers.consolidations.routes.DisassociateUcrController.displayPage())
         case ShutMUCR            => Redirect(controllers.consolidations.routes.ShutMucrController.displayPage())
         case Submissions         => Redirect(controllers.routes.MovementsController.displayPage())
       }

--- a/app/controllers/MovementConfirmationController.scala
+++ b/app/controllers/MovementConfirmationController.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions.AuthAction
+import controllers.storage.FlashKeys
+import forms.{Choice, ConsignmentReferences}
+import javax.inject.{Inject, Singleton}
+import models.ReturnToStartException
+import play.api.i18n.I18nSupport
+import play.api.mvc._
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.html.movement_confirmation_page
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class MovementConfirmationController @Inject()(authenticate: AuthAction, mcc: MessagesControllerComponents, page: movement_confirmation_page)(
+  implicit ec: ExecutionContext
+) extends FrontendController(mcc) with I18nSupport {
+
+  def display: Action[AnyContent] = authenticate { implicit request =>
+    val `type` = request.flash.get(FlashKeys.MOVEMENT_TYPE).map(Choice(_)).getOrElse(throw ReturnToStartException)
+    val kind = request.flash.get(FlashKeys.UCR_KIND).getOrElse(throw ReturnToStartException)
+    val reference = request.flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
+    Ok(page(`type`, ConsignmentReferences(kind, reference)))
+  }
+
+}

--- a/app/forms/Choice.scala
+++ b/app/forms/Choice.scala
@@ -46,12 +46,12 @@ object Choice {
 
   case object Arrival extends Choice("arrival")
   case object Departure extends Choice("departure")
-  case object AssociateDUCR extends Choice("associateDUCR")
-  case object DisassociateDUCR extends Choice("disassociateDUCR")
+  case object AssociateUCR extends Choice("associateUCR")
+  case object DisassociateUCR extends Choice("disassociateUCR")
   case object ShutMUCR extends Choice("shutMUCR")
   case object Submissions extends Choice("submissions")
 
-  val allChoices = Seq(Arrival, Departure, AssociateDUCR, DisassociateDUCR, ShutMUCR, Submissions)
+  val allChoices = Seq(Arrival, Departure, AssociateUCR, DisassociateUCR, ShutMUCR, Submissions)
 
   val choiceId = "Choice"
 

--- a/app/handlers/ErrorHandler.scala
+++ b/app/handlers/ErrorHandler.scala
@@ -20,6 +20,7 @@ import config.AppConfig
 import controllers.exception.IncompleteApplication
 import controllers.routes
 import javax.inject.{Inject, Singleton}
+import models.ReturnToStartException
 import play.api.i18n.{I18nSupport, Messages, MessagesApi}
 import play.api.mvc.Results.{BadRequest, InternalServerError}
 import play.api.mvc.{Request, RequestHeader, Result, Results}
@@ -46,7 +47,7 @@ class ErrorHandler @Inject()(appConfig: AppConfig, val messagesApi: MessagesApi,
         Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
       case _: InsufficientEnrolments =>
         Results.SeeOther(routes.UnauthorisedController.onPageLoad().url)
-      case _: IncompleteApplication =>
+      case _: IncompleteApplication | ReturnToStartException =>
         Results.Redirect(routes.StartController.displayStartPage())
       case _ => super.resolveError(rh, ex)
     }

--- a/app/metrics/MovementsMetrics.scala
+++ b/app/metrics/MovementsMetrics.scala
@@ -29,16 +29,16 @@ class MovementsMetrics @Inject()(metrics: Metrics) {
   val timers = Map(
     Arrival.value -> metrics.defaultRegistry.timer(s"$arrivalMetric.timer"),
     Departure.value -> metrics.defaultRegistry.timer(s"$departureMetric.timer"),
-    AssociateDUCR.value -> metrics.defaultRegistry.timer(s"$associationMetric.timer"),
-    DisassociateDUCR.value -> metrics.defaultRegistry.timer(s"$disassociationMetric.timer"),
+    AssociateUCR.value -> metrics.defaultRegistry.timer(s"$associationMetric.timer"),
+    DisassociateUCR.value -> metrics.defaultRegistry.timer(s"$disassociationMetric.timer"),
     ShutMUCR.value -> metrics.defaultRegistry.timer(s"$shutMucr.timer")
   )
 
   val counters = Map(
     Arrival.value -> metrics.defaultRegistry.counter(s"$arrivalMetric.counter"),
     Departure.value -> metrics.defaultRegistry.counter(s"$departureMetric.counter"),
-    AssociateDUCR.value -> metrics.defaultRegistry.counter(s"$associationMetric.counter"),
-    DisassociateDUCR.value -> metrics.defaultRegistry.counter(s"$disassociationMetric.counter"),
+    AssociateUCR.value -> metrics.defaultRegistry.counter(s"$associationMetric.counter"),
+    DisassociateUCR.value -> metrics.defaultRegistry.counter(s"$disassociationMetric.counter"),
     ShutMUCR.value -> metrics.defaultRegistry.counter(s"$shutMucr.counter")
   )
 

--- a/app/models/ReturnToStartException.scala
+++ b/app/models/ReturnToStartException.scala
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-package controllers.storage
+package models
 
-object FlashKeys {
-  val UCR = "UCR"
-  val UCR_KIND = "UCR_KIND"
-  val MOVEMENT_TYPE = "MOVEMENT_TYPE"
-  val CONSOLIDATION_KIND = "CONSOLIDATION_KIND"
-  val MUCR = "MUCR"
-}
+case object ReturnToStartException extends RuntimeException("Invalid Application State. Returning User to the Start.")

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -75,26 +75,26 @@ class SubmissionService @Inject()(
   def submitUcrAssociation(mucrOptions: MucrOptions, associateDucr: AssociateUcr, eori: String)(
     implicit hc: HeaderCarrier
   ): Future[ConsolidationRequest] = {
-    val timer = metrics.startTimer(AssociateDUCR)
+    val timer = metrics.startTimer(AssociateUCR)
     connector
       .sendConsolidationRequest(buildAssociationRequest(eori, mucrOptions.mucr, associateDucr))
       .andThen {
         case Success(_) =>
           auditService.auditAssociate(eori, mucrOptions.mucr, associateDucr.ucr, ACCEPTED.toString)
           timer.stop()
-          metrics.incrementCounter(AssociateDUCR)
+          metrics.incrementCounter(AssociateUCR)
       }
   }
 
   def submitUcrDisassociation(disassociateUcr: DisassociateUcr, eori: String)(implicit hc: HeaderCarrier): Future[ConsolidationRequest] = {
-    val timer = metrics.startTimer(DisassociateDUCR)
+    val timer = metrics.startTimer(DisassociateUCR)
     connector
       .sendConsolidationRequest(buildDisassociationRequest(eori, disassociateUcr))
       .andThen {
         case Success(_) =>
           auditService.auditDisassociate(eori, disassociateUcr.ucr, ACCEPTED.toString)
           timer.stop()
-          metrics.incrementCounter(DisassociateDUCR)
+          metrics.incrementCounter(DisassociateUCR)
       }
   }
 

--- a/app/views/associate_ucr_confirmation.scala.html
+++ b/app/views/associate_ucr_confirmation.scala.html
@@ -24,8 +24,8 @@
 @()(implicit request: Request[_], flash: Flash, messages: Messages)
 
 @prefix = @{ s"associate.${flash(FlashKeys.CONSOLIDATION_KIND)}.confirmation" }
-@associateLink = {<a href="@routes.ChoiceController.startSpecificJourney("associateDUCR")">@messages("association.confirmation.associateOrDepart.associate")</a>}
-@shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney("departure")">@messages("association.confirmation.associateOrDepart.depart")</a>}
+@associateLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR.value)">@messages("association.confirmation.associateOrDepart.associate")</a>}
+@shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.Departure.value)">@messages("association.confirmation.associateOrDepart.depart")</a>}
 
 @main_template(title = Title(s"${prefix}.tab.heading")) {
 

--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -40,8 +40,8 @@
             legend = "",
             inputs = Seq(
                 RadioOption("arrival", Arrival.value, messages(s"movement.choice.arrival.label")),
-                RadioOption("associate", AssociateDUCR.value, messages(s"movement.choice.associate.label")),
-                RadioOption("disassociate", DisassociateDUCR.value, messages(s"movement.choice.disassociateDucr.label")),
+                RadioOption("associate", AssociateUCR.value, messages(s"movement.choice.associate.label")),
+                RadioOption("disassociate", DisassociateUCR.value, messages(s"movement.choice.disassociateDucr.label")),
                 RadioOption("shut_mucr", ShutMUCR.value, messages("movement.choice.shutMucr.label")),
                 RadioOption("departure", Departure.value, messages(s"movement.choice.departure.label")),
                 RadioOption("submissions", Submissions.value, messages("movement.choice.submissions.label"))

--- a/app/views/components/confirmation_status_info.scala.html
+++ b/app/views/components/confirmation_status_info.scala.html
@@ -17,7 +17,7 @@
 @()(implicit messages: Messages)
 
 <p id="status-info">
-    @submissionLink = {<a href="@routes.ChoiceController.startSpecificJourney("submissions")">@messages("movement.confirmation.statusInfo.submissions")</a>}
+    @submissionLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.Submissions.value)">@messages("movement.confirmation.statusInfo.submissions")</a>}
 
     @Html(messages("movement.confirmation.statusInfo", submissionLink))
 </p>

--- a/app/views/disassociate_ucr_confirmation.scala.html
+++ b/app/views/disassociate_ucr_confirmation.scala.html
@@ -23,8 +23,8 @@
 
 @()(implicit request: Request[_], flash: Flash, messages: Messages)
 
-@associateLink = {<a href="@routes.ChoiceController.startSpecificJourney("associateDUCR")">@messages("disassociation.confirmation.associateOrShut.associate")</a>}
-@shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney("shutMUCR")">@messages("disassociation.confirmation.associateOrShut.shut")</a>}
+@associateLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR.value)">@messages("disassociation.confirmation.associateOrShut.associate")</a>}
+@shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR.value)">@messages("disassociation.confirmation.associateOrShut.shut")</a>}
 @kind = @{flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse("")}
 
 @main_template(title = Title(messages("disassociate.ucr.confirmation.tab.heading", kind))) {

--- a/app/views/movement_confirmation_page.scala.html
+++ b/app/views/movement_confirmation_page.scala.html
@@ -16,24 +16,23 @@
 
 @import forms.{Choice, ConsignmentReferences}
 @import views.Title
-@import models.requests.JourneyRequest
 
 @this(main_template: views.html.main_template)
 
-@(consignmentReferences: ConsignmentReferences)(implicit request: JourneyRequest[_], messages: Messages)
+@(choice: Choice, consignmentReferences: ConsignmentReferences)(implicit request: Request[_], messages: Messages)
 
-@associateLink = {<a href="@routes.ChoiceController.startSpecificJourney("associateDUCR")">@messages("movement.arrival.confirmation.nextSteps.associate")</a>}
-@departureLinkForArrival = {<a href="@routes.ChoiceController.startSpecificJourney("departure")">@messages("movement.arrival.confirmation.nextSteps.depart")</a>}
-@departureLinkForDeparture = {<a href="@routes.ChoiceController.startSpecificJourney("departure")">@messages("movement.departure.confirmation.nextSteps.depart")</a>}
-@arrivalLink = {<a href="@routes.ChoiceController.startSpecificJourney("arrival")">@messages("movement.departure.confirmation.nextSteps.arrive")</a>}
+@associateLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR.value)">@messages("movement.arrival.confirmation.nextSteps.associate")</a>}
+@departureLinkForArrival = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.Departure.value)">@messages("movement.arrival.confirmation.nextSteps.depart")</a>}
+@departureLinkForDeparture = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.Departure.value)">@messages("movement.departure.confirmation.nextSteps.depart")</a>}
+@arrivalLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.Arrival.value)">@messages("movement.departure.confirmation.nextSteps.arrive")</a>}
 
 @main_template(
-    title = Title(s"movement.${request.choice.value}.confirmation.tab.heading")
+    title = Title(s"movement.${choice.value}.confirmation.tab.heading")
 ) {
 
     @components.highlight_box_with_reference(
         headingText = messages(
-            s"movement.${request.choice.value}.confirmation.heading",
+            s"movement.${choice.value}.confirmation.heading",
             if(consignmentReferences.reference == "D") "DUCR" else "MUCR",
             consignmentReferences.referenceValue
         )
@@ -43,12 +42,12 @@
 
     <h2 id="what-next">@messages("movement.confirmation.whatNext")</h2>
 
-    @if(request.choice.isArrival) {
+    @if(choice.isArrival) {
         <div id="next-steps">
             @Html(messages("movement.arrival.confirmation.nextSteps", associateLink, departureLinkForArrival))
         </div>
     }
-    @if(request.choice.isDeparture) {
+    @if(choice.isDeparture) {
         <div id="next-steps">
             @Html(messages("movement.departure.confirmation.nextSteps", departureLinkForDeparture, arrivalLink))
         </div>

--- a/app/views/shut_mucr_confirmation.scala.html
+++ b/app/views/shut_mucr_confirmation.scala.html
@@ -22,8 +22,8 @@
 
 @()(implicit request: Request[_], flash: Flash, messages: Messages)
 
-@shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney("shutMUCR")">@messages("shutMucr.confirmation.nextSteps.shutMucr")</a>}
-@departureLink = {<a href="@routes.ChoiceController.startSpecificJourney("departure")">@messages("shutMucr.confirmation.nextSteps.depart")</a>}
+@shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR.value)">@messages("shutMucr.confirmation.nextSteps.shutMucr")</a>}
+@departureLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.Departure.value)">@messages("shutMucr.confirmation.nextSteps.depart")</a>}
 
 @main_template(title = Title("shutMucr.confirmation.tab.heading")) {
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -61,6 +61,9 @@ POST        /transport                             controllers.TransportControll
 GET         /summary                               controllers.SummaryController.displayPage()
 POST        /summary                               controllers.SummaryController.submitMovementRequest()
 
+# Movement confirmation page
+GET         /movement-confirmation                 controllers.MovementConfirmationController.display()
+
 # Shut a MUCR
 GET         /shut-mucr                             controllers.consolidations.ShutMucrController.displayPage()
 POST        /shut-mucr                             controllers.consolidations.ShutMucrController.submitForm()

--- a/test/handlers/ErrorHandlerSpec.scala
+++ b/test/handlers/ErrorHandlerSpec.scala
@@ -21,6 +21,7 @@ import java.net.URLEncoder
 import base.MovementBaseSpec
 import config.AppConfig
 import controllers.exception.IncompleteApplication
+import models.ReturnToStartException
 import play.api.http.{HeaderNames, Status}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -73,6 +74,12 @@ class ErrorHandlerSpec extends MovementBaseSpec {
 
     "handle incomplete application exception" in {
       val res = errorHandler.resolveError(req, IncompleteApplication)
+      res.header.status must be(Status.SEE_OTHER)
+      res.header.headers.get(HeaderNames.LOCATION) must be(Some(controllers.routes.StartController.displayStartPage().url))
+    }
+
+    "handle return to start exception" in {
+      val res = errorHandler.resolveError(req, ReturnToStartException)
       res.header.status must be(Status.SEE_OTHER)
       res.header.headers.get(HeaderNames.LOCATION) must be(Some(controllers.routes.StartController.displayStartPage().url))
     }

--- a/test/unit/controllers/ChoiceControllerSpec.scala
+++ b/test/unit/controllers/ChoiceControllerSpec.scala
@@ -121,7 +121,7 @@ class ChoiceControllerSpec extends ControllerSpec with OptionValues with BeforeA
 
       "choice is Associate Ducr" in {
 
-        val associateDUCRForm = JsObject(Map("choice" -> JsString(AssociateDUCR.value)))
+        val associateDUCRForm = JsObject(Map("choice" -> JsString(AssociateUCR.value)))
 
         val result = controller.submitChoice()(postRequest(associateDUCRForm))
 
@@ -131,7 +131,7 @@ class ChoiceControllerSpec extends ControllerSpec with OptionValues with BeforeA
 
       "choice is Disassociate Ducr" in {
 
-        val disassociateDUCRForm = JsObject(Map("choice" -> JsString(DisassociateDUCR.value)))
+        val disassociateDUCRForm = JsObject(Map("choice" -> JsString(DisassociateUCR.value)))
 
         val result = controller.submitChoice()(postRequest(disassociateDUCRForm))
 
@@ -186,7 +186,7 @@ class ChoiceControllerSpec extends ControllerSpec with OptionValues with BeforeA
 
       "choice is association" in {
 
-        val result = controller.startSpecificJourney(AssociateDUCR.value)(getRequest())
+        val result = controller.startSpecificJourney(AssociateUCR.value)(getRequest())
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result).value mustBe consolidationRoutes.MucrOptionsController.displayPage().url
@@ -197,7 +197,7 @@ class ChoiceControllerSpec extends ControllerSpec with OptionValues with BeforeA
 
       "choice is disassocitation" in {
 
-        val result = controller.startSpecificJourney(DisassociateDUCR.value)(getRequest())
+        val result = controller.startSpecificJourney(DisassociateUCR.value)(getRequest())
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result).value mustBe consolidationRoutes.DisassociateUcrController.displayPage().url

--- a/test/unit/controllers/MovementConfirmationControllerSpec.scala
+++ b/test/unit/controllers/MovementConfirmationControllerSpec.scala
@@ -77,9 +77,7 @@ class MovementConfirmationControllerSpec extends ControllerSpec {
       "ucr is missing" in {
         authorizedUser()
         intercept[RuntimeException] {
-          await(
-            controller().display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> Choice.Arrival.value, FlashKeys.UCR_KIND -> "kind"))
-          )
+          await(controller().display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> Choice.Arrival.value, FlashKeys.UCR_KIND -> "kind")))
         } mustBe ReturnToStartException
       }
     }

--- a/test/unit/controllers/MovementConfirmationControllerSpec.scala
+++ b/test/unit/controllers/MovementConfirmationControllerSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.controllers
+
+import controllers.MovementConfirmationController
+import controllers.storage.FlashKeys
+import forms.{Choice, ConsignmentReferences}
+import models.ReturnToStartException
+import org.mockito.ArgumentMatchers.{any, _}
+import org.mockito.Mockito.{verify, when}
+import play.api.http.Status
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.twirl.api.HtmlFormat
+import unit.base.ControllerSpec
+import views.html.movement_confirmation_page
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class MovementConfirmationControllerSpec extends ControllerSpec {
+
+  private val page = mock[movement_confirmation_page]
+
+  private def controller() =
+    new MovementConfirmationController(mockAuthAction, stubMessagesControllerComponents(), page)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+
+    authorizedUser()
+    setupErrorHandler()
+    when(page.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  "GET" should {
+    implicit val get = FakeRequest("GET", "/")
+
+    "return 200 when authenticated" in {
+      authorizedUser()
+
+      val result = controller()
+        .display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> Choice.Arrival.value, FlashKeys.UCR_KIND -> "kind", FlashKeys.UCR -> "123"))
+
+      status(result) mustBe Status.OK
+      verify(page).apply(refEq(Choice.Arrival), refEq(ConsignmentReferences("kind", "123")))(any(), any())
+    }
+
+    "return to start" when {
+      "journey type is missing" in {
+        authorizedUser()
+        intercept[RuntimeException] {
+          await(controller().display(get.withFlash(FlashKeys.UCR_KIND -> "kind", FlashKeys.UCR -> "123")))
+        } mustBe ReturnToStartException
+      }
+
+      "ucr kind is missing" in {
+        authorizedUser()
+        intercept[RuntimeException] {
+          await(controller().display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> Choice.Arrival.value, FlashKeys.UCR -> "123")))
+        } mustBe ReturnToStartException
+      }
+
+      "ucr is missing" in {
+        authorizedUser()
+        intercept[RuntimeException] {
+          await(
+            controller().display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> Choice.Arrival.value, FlashKeys.UCR_KIND -> "kind"))
+          )
+        } mustBe ReturnToStartException
+      }
+    }
+  }
+}

--- a/test/unit/controllers/consolidations/AssociateUcrConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUcrConfirmationControllerSpec.scala
@@ -18,7 +18,7 @@ package unit.controllers.consolidations
 
 import controllers.consolidations.AssociateUcrConfirmationController
 import forms.Choice
-import forms.Choice.AssociateDUCR
+import forms.Choice.AssociateUCR
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify, when}
 import play.api.test.Helpers._
@@ -37,7 +37,7 @@ class AssociateUcrConfirmationControllerSpec extends ControllerSpec {
     super.beforeEach()
 
     authorizedUser()
-    withCaching(Choice.choiceId, Some(AssociateDUCR))
+    withCaching(Choice.choiceId, Some(AssociateUCR))
     when(mockAssociateDucrConfirmPage.apply()(any(), any(), any())).thenReturn(HtmlFormat.empty)
   }
 

--- a/test/unit/controllers/consolidations/AssociateUcrControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUcrControllerSpec.scala
@@ -19,7 +19,7 @@ package unit.controllers.consolidations
 import controllers.consolidations.{routes, AssociateUcrController}
 import controllers.exception.IncompleteApplication
 import controllers.storage.CacheIdGenerator._
-import forms.Choice.AssociateDUCR
+import forms.Choice.AssociateUCR
 import forms.{AssociateUcr, Choice, MucrOptions}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -49,7 +49,7 @@ class AssociateUcrControllerSpec extends ControllerSpec {
     super.beforeEach()
 
     authorizedUser()
-    withCaching(Choice.choiceId, Some(AssociateDUCR))
+    withCaching(Choice.choiceId, Some(AssociateUCR))
     withCaching(AssociateUcr.formId)
     when(mockAssociateDucrPage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }

--- a/test/unit/controllers/consolidations/AssociateUcrSummaryControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUcrSummaryControllerSpec.scala
@@ -20,7 +20,7 @@ import base.MockSubmissionService
 import controllers.consolidations.AssociateUcrSummaryController
 import controllers.exception.IncompleteApplication
 import controllers.storage.FlashKeys
-import forms.Choice.AssociateDUCR
+import forms.Choice.AssociateUCR
 import forms.{AssociateUcr, Choice, MucrOptions}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -53,7 +53,7 @@ class AssociateUcrSummaryControllerSpec extends ControllerSpec with MockSubmissi
 
     authorizedUser()
     when(mockAssociateDucrSummaryPage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
-    withCaching(Choice.choiceId, Some(AssociateDUCR))
+    withCaching(Choice.choiceId, Some(AssociateUCR))
   }
 
   override protected def afterEach(): Unit = {

--- a/test/unit/controllers/consolidations/DisassociateUcrConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUcrConfirmationControllerSpec.scala
@@ -18,7 +18,7 @@ package unit.controllers.consolidations
 
 import controllers.consolidations.DisassociateUcrConfirmationController
 import forms.Choice
-import forms.Choice.DisassociateDUCR
+import forms.Choice.DisassociateUCR
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify, when}
 import play.api.test.Helpers._
@@ -43,7 +43,7 @@ class DisassociateUcrConfirmationControllerSpec extends ControllerSpec {
     super.beforeEach()
 
     authorizedUser()
-    withCaching(Choice.choiceId, Some(DisassociateDUCR))
+    withCaching(Choice.choiceId, Some(DisassociateUCR))
     when(mockDisassociateDucrConfirmationPage.apply()(any(), any(), any())).thenReturn(HtmlFormat.empty)
   }
 

--- a/test/unit/controllers/consolidations/DisassociateUcrControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUcrControllerSpec.scala
@@ -18,7 +18,7 @@ package unit.controllers.consolidations
 
 import base.MockSubmissionService
 import controllers.consolidations.{routes, DisassociateUcrController}
-import forms.Choice.DisassociateDUCR
+import forms.Choice.DisassociateUCR
 import forms._
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
@@ -52,7 +52,7 @@ class DisassociateUcrControllerSpec extends ControllerSpec with MockSubmissionSe
     super.beforeEach()
 
     authorizedUser()
-    withCaching(Choice.choiceId, Some(DisassociateDUCR))
+    withCaching(Choice.choiceId, Some(DisassociateUCR))
     withCaching(DisassociateUcr.formId, None)
     withCaching(DisassociateUcr.formId)
     when(mockDisassociateUcrPage.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)

--- a/test/unit/controllers/consolidations/DisassociateUcrSummaryControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUcrSummaryControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.consolidations.DisassociateUcrSummaryController
 import controllers.exception.IncompleteApplication
 import controllers.storage.FlashKeys
 import forms.AssociateKind._
-import forms.Choice.DisassociateDUCR
+import forms.Choice.DisassociateUCR
 import forms.{DisassociateKind, _}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -55,7 +55,7 @@ class DisassociateUcrSummaryControllerSpec extends ControllerSpec with MockSubmi
     authorizedUser()
     setupErrorHandler()
     when(mockDisassociateUcrSummaryPage.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)
-    withCaching(Choice.choiceId, Some(DisassociateDUCR))
+    withCaching(Choice.choiceId, Some(DisassociateUCR))
   }
 
   override protected def afterEach(): Unit = {

--- a/test/unit/controllers/consolidations/MucrOptionsControllerSpec.scala
+++ b/test/unit/controllers/consolidations/MucrOptionsControllerSpec.scala
@@ -17,7 +17,7 @@
 package unit.controllers.consolidations
 
 import controllers.consolidations.{routes, MucrOptionsController}
-import forms.Choice.AssociateDUCR
+import forms.Choice.AssociateUCR
 import forms.MucrOptions.Create
 import forms.{Choice, MucrOptions}
 import org.mockito.ArgumentCaptor
@@ -48,7 +48,7 @@ class MucrOptionsControllerSpec extends ControllerSpec with OptionValues {
     super.beforeEach()
 
     authorizedUser()
-    withCaching(Choice.choiceId, Some(AssociateDUCR))
+    withCaching(Choice.choiceId, Some(AssociateUCR))
     withCaching(MucrOptions.formId, None)
     when(mockMucrOptionsPage.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)
   }

--- a/test/views/AssociateDucrConfirmationViewSpec.scala
+++ b/test/views/AssociateDucrConfirmationViewSpec.scala
@@ -78,17 +78,17 @@ class AssociateDucrConfirmationViewSpec extends UnitViewSpec with CommonMessages
 
     "link to list of submissions" in {
       pending
-      view.getElementsByAttributeValue("href", routes.ChoiceController.startSpecificJourney("submissions").url) mustNot be(empty)
+      view.getElementsByAttributeValue("href", routes.ChoiceController.startSpecificJourney(forms.Choice.Submissions.value).url) mustNot be(empty)
     }
 
     "link to start another association" in {
       pending
-      view.getElementsByAttributeValue("href", routes.ChoiceController.startSpecificJourney("associateDUCR").url).size() mustBe >(0)
+      view.getElementsByAttributeValue("href", routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR.value).url).size() mustBe >(0)
     }
 
     "link to shut mucr" in {
       pending
-      view.getElementsByAttributeValue("href", routes.ChoiceController.startSpecificJourney("shutMUCR").url).size() mustBe >(0)
+      view.getElementsByAttributeValue("href", routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR.value).url).size() mustBe >(0)
     }
   }
 

--- a/test/views/ChoiceViewSpec.scala
+++ b/test/views/ChoiceViewSpec.scala
@@ -159,7 +159,7 @@ class ChoiceViewSpec extends UnitViewSpec with ChoiceMessages with CommonMessage
 
     "display selected 3rd radio button - Disassociate (EAC)" in {
 
-      val view = createView(Choice.form().fill(DisassociateDUCR))
+      val view = createView(Choice.form().fill(DisassociateUCR))
 
       ensureRadioIsUnChecked(view, "arrival")
       ensureRadioIsUnChecked(view, "departure")

--- a/test/views/MovementConfirmationViewSpec.scala
+++ b/test/views/MovementConfirmationViewSpec.scala
@@ -18,11 +18,11 @@ package views
 
 import controllers.routes
 import forms.Choice.{Arrival, Departure}
-import forms.ConsignmentReferences
+import forms.{Choice, ConsignmentReferences}
 import helpers.views.CommonMessages
 import testdata.CommonTestData.correctUcr
 import views.html.movement_confirmation_page
-import views.spec.{UnitViewSpec, ViewMatchers}
+import views.spec.UnitViewSpec
 
 class MovementConfirmationViewSpec extends UnitViewSpec with CommonMessages {
 
@@ -30,8 +30,8 @@ class MovementConfirmationViewSpec extends UnitViewSpec with CommonMessages {
   val consignmentReferences = ConsignmentReferences(ConsignmentReferences.AllowedReferences.Ducr, correctUcr)
   val arrivalRequest = fakeJourneyRequest(Arrival)
   val departureRequest = fakeJourneyRequest(Departure)
-  val arrivalConfirmationView = movementConfirmationPage(consignmentReferences)(arrivalRequest, messages)
-  val departureConfirmationView = movementConfirmationPage(consignmentReferences)(departureRequest, messages)
+  val arrivalConfirmationView = movementConfirmationPage(Choice.Arrival, consignmentReferences)(arrivalRequest, messages)
+  val departureConfirmationView = movementConfirmationPage(Choice.Departure, consignmentReferences)(departureRequest, messages)
 
   "Movement Confirmation Page" should {
 


### PR DESCRIPTION
Key Changes:
- Movements confirmation changed to POST/Redirect/GET
- Choice: `associateDUCR =>  associateUCR`
- Choice: `disossiateDUCR => disossiateUCR`