### PR TITLE
CEDS-1976 Change back button id

### DIFF
--- a/app/views/components/back_link.scala.html
+++ b/app/views/components/back_link.scala.html
@@ -17,5 +17,5 @@
 @(href: Call)(implicit messages: Messages)
 
 <div class="js-visible">
-    <a id="link-back" class="link-back" href="@{href.url}">@messages("site.back")</a>
+    <a id="back-link" class="link-back" href="@{href.url}">@messages("site.back")</a>
 </div>

--- a/test/views/ArrivalReferenceViewSpec.scala
+++ b/test/views/ArrivalReferenceViewSpec.scala
@@ -67,7 +67,7 @@ class ArrivalReferenceViewSpec extends UnitViewSpec {
 
     "have back button" in {
 
-      val backButton = createView().getElementById("link-back")
+      val backButton = createView().getElementById("back-link")
 
       backButton must containMessage("site.back")
       backButton must haveHref(routes.ConsignmentReferencesController.displayPage())

--- a/test/views/ChoiceViewSpec.scala
+++ b/test/views/ChoiceViewSpec.scala
@@ -75,7 +75,7 @@ class ChoiceViewSpec extends UnitViewSpec with ChoiceMessages with CommonMessage
 
     "display 'Back' button that links to 'Make an export declaration' page" in {
 
-      val backButton = createView().getElementById("link-back")
+      val backButton = createView().getElementById("back-link")
 
       backButton.text() must be(messages(backCaption))
       backButton.attr("href") must be(controllers.routes.StartController.displayStartPage().url)

--- a/test/views/DepartureDetailsViewSpec.scala
+++ b/test/views/DepartureDetailsViewSpec.scala
@@ -73,7 +73,7 @@ class DepartureDetailsViewSpec extends UnitViewSpec with DepartureDetailsMessage
 
     "display \"Back\" button that links to Consignment References" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() must be(backCaption)
       backButton must haveHref(routes.ConsignmentReferencesController.displayPage())

--- a/test/views/LocationViewSpec.scala
+++ b/test/views/LocationViewSpec.scala
@@ -62,7 +62,7 @@ class LocationViewSpec extends UnitViewSpec with CommonMessages {
 
     "display \"Back\" button that links to Movement Details" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() must be(messages(backCaption))
       backButton must haveHref(routes.MovementDetailsController.displayPage())

--- a/test/views/MucrOptionsViewSpec.scala
+++ b/test/views/MucrOptionsViewSpec.scala
@@ -53,7 +53,7 @@ class MucrOptionsViewSpec extends UnitViewSpec with CommonMessages {
     }
 
     "display 'Back' button that links to start page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
       backButton.text() must be(backCaption)
       backButton must haveHref(controllers.routes.ChoiceController.displayChoiceForm())
     }

--- a/test/views/TransportViewSpec.scala
+++ b/test/views/TransportViewSpec.scala
@@ -88,7 +88,7 @@ class TransportViewSpec extends UnitViewSpec with TransportMessages with CommonM
 
     "display \"Back\" button that links to Location" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() must be(messages(backCaption))
       backButton.attr("href") mustBe routes.LocationController.displayPage().url

--- a/test/views/ViewSpec.scala
+++ b/test/views/ViewSpec.scala
@@ -43,7 +43,7 @@ class ViewSpec extends WordSpec with MustMatchers with ViewTemplates with ViewMa
 
     def getTitle: Element = document.getElementsByTag("title").first()
 
-    def getBackButton: Option[Element] = Option(document.getElementById("link-back"))
+    def getBackButton: Option[Element] = Option(document.getElementById("back-link"))
 
     def getSubmitButton: Option[Element] = Option(document.getElementById("submit"))
 


### PR DESCRIPTION
Change back button HTML id from `link-back` to `back-link`
This is to align ourselves with the GDS design system compoenent.