### PR TITLE
CEDS-1783 Amend associate MUCR change tag id

### DIFF
--- a/app/views/associate_ucr_summary.scala.html
+++ b/app/views/associate_ucr_summary.scala.html
@@ -59,7 +59,7 @@
                     <td id="mucr-type">@messages("associate.ucr.summary.kind.mucr")</td>
                     <td id="mucr-reference">@mucr</td>
                     <td class="text-right">
-                        <a id="mucr-change" href="@consolidations.routes.MucrOptionsController.displayPage()">
+                        <a id="associate_mucr-change" href="@consolidations.routes.MucrOptionsController.displayPage()">
                             <span aria-hidden="true">@messages("site.change")</span>
                             <span class="visuallyhidden">
                                 @{messages("site.change.hint.associate.mucr")}

--- a/test/views/AssociateDucrSummaryViewSpec.scala
+++ b/test/views/AssociateDucrSummaryViewSpec.scala
@@ -56,8 +56,8 @@ class AssociateDucrSummaryViewSpec extends UnitViewSpec with CommonMessages {
 
     "display 'Change' link on the page for mucr" in {
 
-      view.getElementById("mucr-change") must containMessage(changeCaption)
-      view.getElementById("mucr-change") must haveHref(controllers.consolidations.routes.MucrOptionsController.displayPage())
+      view.getElementById("associate_mucr-change") must containMessage(changeCaption)
+      view.getElementById("associate_mucr-change") must haveHref(controllers.consolidations.routes.MucrOptionsController.displayPage())
     }
 
     "display 'Reference' link on page" in {


### PR DESCRIPTION
* I missed an updated of the mucr change tag id from `mucr-change` to
  `associate_mucr-change`. This change is to align the ids with the same
  format in other places.

* This change was already done in the acceptance tests suite and the
  movements-regression tests failed.