### PR TITLE
CEDS-2024 refactor Title component

### DIFF
--- a/app/views/arrival_details.scala.html
+++ b/app/views/arrival_details.scala.html
@@ -22,7 +22,7 @@
 
 @(form: Form[ArrivalDetails])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title("arrivalDetails.header", None)) {
+@main_template(title = Title("arrivalDetails.header")) {
     @helper.form(routes.MovementDetailsController.saveMovementDetails(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 

--- a/app/views/arrival_reference.scala.html
+++ b/app/views/arrival_reference.scala.html
@@ -21,7 +21,7 @@
 
 @(form: Form[ArrivalReference])(implicit request: Request[_], messages: Messages)
 
-@main_template(Title("arrivalReference.question", None)) {
+@main_template(Title("arrivalReference.question")) {
 
     @helper.form(controllers.routes.ArrivalReferenceController.submit(), 'autoComplete -> "off") {
         @helper.CSRF.formField

--- a/app/views/associate_ucr.scala.html
+++ b/app/views/associate_ucr.scala.html
@@ -26,6 +26,7 @@
         govukButton: GovukButton,
         govukRadios: GovukRadios,
         govukInput: GovukInput,
+        exportsInputText: components.gds.exportsInputText,
         errorSummary: components.errorSummary,
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF)
 
@@ -58,27 +59,17 @@
                     value = Some(AssociateKind.Ducr.formValue),
                     content = Text(messages("associate.ucr.ducr")),
                     checked = form("kind").value.contains(AssociateKind.Ducr.formValue),
-                    conditionalHtml = Some(conditionalHtml("ducr"))
+                    conditionalHtml = Some(exportsInputText(form("ducr")))
                 ),
                 RadioItem(
                     value = Some(AssociateKind.Mucr.formValue),
                     content = Text(messages("associate.ucr.mucr")),
                     checked = form("kind").value.contains(AssociateKind.Mucr.formValue),
-                    conditionalHtml = Some(conditionalHtml("mucr"))
+                    conditionalHtml = Some(exportsInputText(form("mucr")))
                 )
             ),
             errorMessage = form("kind").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
         ))
         @govukButton(Button(content = Text(messages("site.continue"))))
     }
-}
-
-@conditionalHtml(field: String) = {
-    @govukInput(Input(
-        id = field,
-        name = field,
-        value = form(field).value,
-        errorMessage = form(field).error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*)))),
-        classes = "govuk-!-width-two-thirds"
-    ))
 }

--- a/app/views/associate_ucr.scala.html
+++ b/app/views/associate_ucr.scala.html
@@ -28,19 +28,20 @@
         govukInput: GovukInput,
         exportsInputText: components.gds.exportsInputText,
         errorSummary: components.errorSummary,
+        sectionHeader: components.sectionHeader,
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF)
 
 @(form: Form[AssociateUcr], mucrOptions: MucrOptions)(implicit request: Request[_], messages: Messages)
 
 @govukLayout(
-    title = Title(messages("associate.ucr.title", mucrOptions.mucr)),
+    title = Title("associate.ucr.title", Some("mucrOptions.heading")),
     backButtonTitle = messages("site.back"),
     backButtonUrl = consolidations.routes.MucrOptionsController.displayPage.url) {
 
     @formHelper(action = consolidations.routes.AssociateUcrController.submit(), 'autoComplete -> "off") {
         @errorSummary(form.errors)
 
-        <span class="govuk-caption-xl">@messages("associate.heading", mucrOptions.mucr)</span>
+        @sectionHeader(messages("associate.heading", mucrOptions.mucr))
 
         @govukRadios(Radios(
             name = "kind",

--- a/app/views/associate_ucr_confirmation.scala.html
+++ b/app/views/associate_ucr_confirmation.scala.html
@@ -27,7 +27,7 @@
 @associateLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR.value)">@messages("association.confirmation.associateOrDepart.associate")</a>}
 @shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.Departure.value)">@messages("association.confirmation.associateOrDepart.depart")</a>}
 
-@main_template(title = Title(s"${prefix}.tab.heading", None)) {
+@main_template(title = Title(s"${prefix}.tab.heading")) {
 
     @components.highlight_box_with_reference(
         headingText = messages(s"${prefix}.heading", flash.get(FlashKeys.UCR).getOrElse("-"))

--- a/app/views/associate_ucr_summary.scala.html
+++ b/app/views/associate_ucr_summary.scala.html
@@ -21,7 +21,7 @@
 
 @(associateUcr: AssociateUcr, mucr: String)(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title(messages("associate.ucr.summary.title", mucr)), fullWidth = true) {
+@main_template(title = Title("associate.ucr.summary.title"), fullWidth = true) {
 
     @helper.form(consolidations.routes.AssociateUcrSummaryController.submit(), 'autoComplete -> "off") {
         @helper.CSRF.formField

--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -30,7 +30,7 @@ appConfig: AppConfig)
 @(form: Form[Choice])(implicit request: Request[_], messages: Messages)
 
 @govukLayout(
-    title = Title(messages("movement.choice.title")),
+    title = Title("movement.choice.title"),
     backButtonTitle = messages("site.back"),
     backButtonUrl = controllers.routes.StartController.displayStartPage().url) {
 

--- a/app/views/components/sectionHeader.scala.html
+++ b/app/views/components/sectionHeader.scala.html
@@ -1,4 +1,4 @@
-/*
+@*
  * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,22 +12,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *@
 
-package views
+@this()
 
-import play.api.i18n.Messages
+@(message: String)
 
-case class Title(headingKey: String, sectionKey: Option[String] = None, headingArgs: Seq[String] = Seq.empty) {
-
-  def format(implicit messages: Messages): String = {
-    val heading = messages(headingKey, headingArgs: _*)
-    val service = messages("service.name")
-
-    sectionKey match {
-      case Some(section) => messages("title.withSection.format", heading, messages(section), service)
-      case _             => messages("title.format", heading, service)
-    }
-
-  }
-}
+<span id="section-header" class="govuk-caption-xl">@message</span>

--- a/app/views/consignment_references.scala.html
+++ b/app/views/consignment_references.scala.html
@@ -29,26 +29,30 @@
   govukRadios: GovukRadios,
   exportsInputText: components.gds.exportsInputText,
   errorSummary: components.errorSummary,
+  sectionHeader: components.sectionHeader,
   formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(form: Form[ConsignmentReferences])(implicit request: JourneyRequest[_], messages: Messages)
 
+@headerKey = @{s"consignmentReferences.${request.answers.`type`}.question"}
+@sectionHeaderKey = @{s"consignmentReferences.${request.answers.`type`}.heading"}
+
 @govukLayout(
-  title = Title(messages("consignmentReferences.title")),
+  title = Title(headerKey, Some(sectionHeaderKey)),
   backButtonTitle = messages("site.back.toStartPage"),
   backButtonUrl = controllers.routes.ChoiceController.displayChoiceForm().url) {
 
   @formHelper(action = routes.ConsignmentReferencesController.saveConsignmentReferences(), 'autoComplete -> "off") {
     @errorSummary(form.errors)
 
-    <span id="section-header" class="govuk-caption-xl">@messages(s"consignmentReferences.${request.answers.`type`}.heading")</span>
+     @sectionHeader(messages(sectionHeaderKey))
 
-    @govukRadios(Radios(
+      @govukRadios(Radios(
       name = "reference",
       fieldset = Some(Fieldset(
         legend = Some(Legend(
-          content = Text(messages(s"consignmentReferences.${request.answers.`type`}.question")),
+          content = Text(messages(headerKey)),
           isPageHeading = true,
           classes = "govuk-fieldset__legend govuk-fieldset__legend--l"
         ))

--- a/app/views/departure_details.scala.html
+++ b/app/views/departure_details.scala.html
@@ -22,7 +22,7 @@
 
 @(form: Form[DepartureDetails])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title("departureDetails.header", None)) {
+@main_template(title = Title("departureDetails.header")) {
     @helper.form(routes.MovementDetailsController.saveMovementDetails(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 

--- a/app/views/disassociate_ucr.scala.html
+++ b/app/views/disassociate_ucr.scala.html
@@ -24,7 +24,7 @@
 
 @(form: Form[DisassociateUcr])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title("disassociate.ucr.title", None)) {
+@main_template(title = Title("disassociate.ucr.title", Some("disassociate.ucr.heading"))) {
     @helper.form(consolidations.routes.DisassociateUcrController.submit(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 

--- a/app/views/disassociate_ucr_confirmation.scala.html
+++ b/app/views/disassociate_ucr_confirmation.scala.html
@@ -33,7 +33,7 @@
     flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse("")
 }
 
-@main_template(title = Title(messages("disassociate.ucr.confirmation.tab.heading", kind))) {
+@main_template(title = Title(s"disassociate.ucr.confirmation.$kind.title")) {
 
     @components.highlight_box_with_reference(
         headingText = messages("disassociate.ucr.confirmation.heading", kind, flash.get(FlashKeys.UCR).getOrElse("-"))

--- a/app/views/disassociate_ucr_summary.scala.html
+++ b/app/views/disassociate_ucr_summary.scala.html
@@ -22,7 +22,7 @@
 @(disassociateUcr: DisassociateUcr)(implicit request: Request[_], messages: Messages)
 
 
-@main_template(title = Title(messages("disassociate.ucr.summary.title")),
+@main_template(title = Title("disassociate.ucr.summary.title"),
     fullWidth = true) {
     @helper.form(consolidations.routes.DisassociateUcrSummaryController.submit(), 'autoComplete -> "off") {
         @helper.CSRF.formField

--- a/app/views/gds_main_template.scala.html
+++ b/app/views/gds_main_template.scala.html
@@ -70,7 +70,7 @@
     )}
 
 @govukLayout(
-    pageTitle = Some(title.title),
+    pageTitle = Some(title.format),
     headBlock = Some(head),
     beforeContentBlock = Some(beforeContentBlock),
     bodyEndBlock = None,

--- a/app/views/location.scala.html
+++ b/app/views/location.scala.html
@@ -22,7 +22,7 @@
 
 @(form: Form[Location])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title("location.question", None)) {
+@main_template(title = Title("location.question")) {
     @helper.form(routes.LocationController.saveLocation(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 

--- a/app/views/main_template.scala.html
+++ b/app/views/main_template.scala.html
@@ -38,7 +38,7 @@
     }
 }
 
-@govuk_wrapper(title = title.title,
+@govuk_wrapper(title = title.format,
                mainClass = mainClass,
                bodyClasses = bodyClasses,
                sidebar = sidebar,

--- a/app/views/movement_confirmation_page.scala.html
+++ b/app/views/movement_confirmation_page.scala.html
@@ -35,7 +35,7 @@
 }
 
 @main_template(
-    title = Title(s"movement.${choice.value}.confirmation.tab.heading", None)
+    title = Title(s"movement.${choice.value}.confirmation.tab.heading")
 ) {
 
     @components.highlight_box_with_reference(

--- a/app/views/movements.scala.html
+++ b/app/views/movements.scala.html
@@ -24,7 +24,7 @@
 
 @(submissions: Seq[(Submission, Seq[Notification])])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title("submissions.title", None),
+@main_template(title = Title("submissions.title"),
     fullWidth = true) {
 
     @components.back_link(routes.ChoiceController.displayChoiceForm())

--- a/app/views/mucr_options.scala.html
+++ b/app/views/mucr_options.scala.html
@@ -23,7 +23,7 @@
 
 @(form: Form[MucrOptions])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title("mucrOptions.title", None)) {
+@main_template(title = Title("mucrOptions.title", Some("mucrOptions.heading"))) {
     @helper.form(consolidations.routes.MucrOptionsController.save(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
@@ -31,7 +31,7 @@
 
         @components.error_summary(form.errors)
 
-        @components.heading(title = messages("mucrOptions.title"), sectionHeader = messages("associate.heading", ""))
+        @components.heading(title = messages("mucrOptions.title"), sectionHeader = messages("mucrOptions.heading"))
 
         @components.input_radio(
             field = form("createOrAdd"),

--- a/app/views/notifications.scala.html
+++ b/app/views/notifications.scala.html
@@ -49,7 +49,7 @@
     </div>
 }
 
-@main_template(title = Title(messages("notifications.title", submissionUcr))) {
+@main_template(title = Title("notifications.title", None, Seq(submissionUcr))) {
 
   <div class="govuk-width-container">
 

--- a/app/views/shut_mucr.scala.html
+++ b/app/views/shut_mucr.scala.html
@@ -21,7 +21,7 @@
 
 @(form: Form[ShutMucr])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title("shutMucr.title", None)) {
+@main_template(title = Title("shutMucr.title")) {
 
     @helper.form(consolidations.routes.ShutMucrController.submitForm(), 'autoComplete -> "off") {
         @helper.CSRF.formField

--- a/app/views/shut_mucr_confirmation.scala.html
+++ b/app/views/shut_mucr_confirmation.scala.html
@@ -25,7 +25,7 @@
 @shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR.value)">@messages("shutMucr.confirmation.nextSteps.shutMucr")</a>}
 @departureLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.Departure.value)">@messages("shutMucr.confirmation.nextSteps.depart")</a>}
 
-@main_template(title = Title("shutMucr.confirmation.tab.heading", None)) {
+@main_template(title = Title("shutMucr.confirmation.tab.heading")) {
 
     @components.highlight_box_with_reference(
         headingText = messages("shutMucr.confirmation.heading", flash.get(FlashKeys.MUCR).getOrElse("-"))

--- a/app/views/shut_mucr_summary.scala.html
+++ b/app/views/shut_mucr_summary.scala.html
@@ -22,7 +22,7 @@
 
 @(shutMucr: ShutMucr)(implicit request: Request[AnyContent], messages: Messages)
 
-@main_template(title = Title(messages("shutMucr.summary.title")), fullWidth = true) {
+@main_template(title = Title("shutMucr.summary.title"), fullWidth = true) {
 
     @helper.form(routes.ShutMucrSummaryController.submit(), 'autoComplete -> "off") {
         @helper.CSRF.formField

--- a/app/views/summary/arrival_summary_page.scala.html
+++ b/app/views/summary/arrival_summary_page.scala.html
@@ -25,7 +25,7 @@
 
 @(data: ArrivalAnswers)(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title("summary.arrival.title", None)) {
+@main_template(title = Title("summary.arrival.title")) {
     @components.back_link(routes.LocationController.displayPage())
 
     @components.page_title(Some(messages("summary.arrival.title")))

--- a/app/views/summary/departure_summary_page.scala.html
+++ b/app/views/summary/departure_summary_page.scala.html
@@ -25,7 +25,7 @@
 
 @(data: DepartureAnswers)(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title("summary.departure.title", None)) {
+@main_template(title = Title("summary.departure.title")) {
 
     @components.back_link(routes.TransportController.displayPage())
 

--- a/app/views/transport.scala.html
+++ b/app/views/transport.scala.html
@@ -26,7 +26,7 @@
 
 @radio(mode: String) = { RadioOption(mode, mode, Transport.messageKey(mode)) }
 
-@main_template(title = Title("transport.title", None)) {
+@main_template(title = Title("transport.title")) {
     @helper.form(routes.TransportController.saveTransport(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 

--- a/conf/messages
+++ b/conf/messages
@@ -176,7 +176,6 @@ startPage.buttonName = Start now
 choicePage.input.error.empty = Please, choose what do you want to do
 choicePage.input.error.incorrectValue = Please, choose valid option
 
-consignmentReferences.title = Consignment references
 consignmentReferences.ARRIVE.heading = Arrive consignment
 consignmentReferences.DEPART.heading = Depart consignment
 consignmentReferences.ARRIVE.question = What consignment do you want to arrive?
@@ -263,7 +262,8 @@ disassociate.ucr.ducr = Declaration Consignment Reference (DUCR)
 disassociate.ucr.mucr = Master Consignment Reference (MUCR)
 disassociate.ucr.summary.title = Is the information provided for this dissociation request correct?
 disassociate.ucr.summary.table.caption = Remove consignment
-disassociate.ucr.confirmation.tab.heading = Request to dissociate {0} submitted
+disassociate.ucr.confirmation.DUCR.title = Request to dissociate DUCR submitted
+disassociate.ucr.confirmation.MUCR.title = Request to dissociate MUCR submitted
 disassociate.ucr.confirmation.heading = Request to dissociate {0} {1} has been submitted
 disassociate.ucr.ducr.error = Declaration Consignment Reference is incorrect
 disassociate.ucr.ducr.empty = Enter a Declaration Consignment Reference
@@ -282,6 +282,7 @@ shutMucr.summary.header = Shut master consignment
 shutMucr.summary.type = MUCR
 
 associate.heading = Add to MUCR {0}
+mucrOptions.heading = Add to MUCR
 mucrOptions.title = Create or enter a Master Consignment Reference (MUCR) to associate with
 mucrOptions.create = Create a new Master Consignment Reference (MUCR)
 mucrOptions.add = Add to an existing Master Consignment Reference (MUCR)

--- a/test/unit/views/ConsignmentReferenceViewSpec.scala
+++ b/test/unit/views/ConsignmentReferenceViewSpec.scala
@@ -31,7 +31,7 @@ class ConsignmentReferenceViewSpec extends ViewSpec with Injector {
 
   "View" should {
     "render title" in {
-      page(ConsignmentReferences.form).getTitle must containMessage("consignmentReferences.title")
+      page(ConsignmentReferences.form).getTitle must containMessage("consignmentReferences.ARRIVE.question")
     }
 
     "render heading" in {

--- a/test/unit/views/DisassociateUcrConfirmationViewSpec.scala
+++ b/test/unit/views/DisassociateUcrConfirmationViewSpec.scala
@@ -40,8 +40,8 @@ class DisassociateUcrConfirmationViewSpec extends UnitViewSpec with CommonMessag
 
       val messages = messagesApi.preferred(request)
 
-      messages must haveTranslationFor("disassociate.ucr.confirmation.tab.heading")
-      messages must haveTranslationFor("disassociate.ucr.confirmation.heading")
+      messages must haveTranslationFor("disassociate.ucr.confirmation.MUCR.title")
+      messages must haveTranslationFor("disassociate.ucr.confirmation.DUCR.title")
       messages must haveTranslationFor("disassociation.confirmation.associateOrShut")
       messages must haveTranslationFor("disassociation.confirmation.associateOrShut.associate")
       messages must haveTranslationFor("disassociation.confirmation.associateOrShut.shut")

--- a/test/unit/views/MessagesStub.scala
+++ b/test/unit/views/MessagesStub.scala
@@ -22,8 +22,8 @@ import play.api.mvc.Request
 
 trait MessagesStub {
 
-  protected implicit def messages(implicit request: Request[_]): Messages = //new AllMessageKeysAreMandatoryMessages(messagesApi.preferred(request))
-    MessagesStub.realMessagesApi.preferred(request) // TODO use Mandatory Key Messages
+  protected implicit def messages(implicit request: Request[_]): Messages =
+    new AllMessageKeysAreMandatoryMessages(MessagesStub.realMessagesApi.preferred(request))
 
   protected def messages(key: String, args: Any*)(implicit request: Request[_]): String = messages(request)(key, args: _*)
 

--- a/test/unit/views/MucrOptionsViewSpec.scala
+++ b/test/unit/views/MucrOptionsViewSpec.scala
@@ -36,7 +36,7 @@ class MucrOptionsViewSpec extends UnitViewSpec with CommonMessages {
     }
 
     "have the correct heading" in {
-      view.getElementById("section-header").text() mustBe "associate.heading"
+      view.getElementById("section-header").text() mustBe "mucrOptions.heading"
     }
 
     "have the correct label for create new" in {


### PR DESCRIPTION
- Refactored the Title component to try and prevent incorrect use.  Aim is to ensure that the page title is always rendered as <title> - <optional section> - <service name> - GOV.UK

- Refactored associate_ucr to use the new exportsInputText component

- Created new sectionHeader component for use with GDS pages