### PR TITLE
CEDS-2087 Cleaning script references

### DIFF
--- a/app/views/components/gds/gds_main_template.scala.html
+++ b/app/views/components/gds/gds_main_template.scala.html
@@ -42,7 +42,6 @@
 @scripts = {
   <script src='@routes.Assets.versioned("lib/govuk-frontend/govuk/all.js")'></script>
   <script src='@routes.Assets.versioned("javascripts/google.tag.manager.min.js")'> </script>
-  <script src="@routes.Assets.versioned("javascripts/autocomplete.js")" type="text/javascript"></script>
   <script src="@routes.Assets.versioned("javascripts/show-hide-content.js")" type="text/javascript"></script>
   <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/vendor/jquery-ui.min.css")' type="text/css" >
   <script>window.GOVUKFrontend.initAll();</script>

--- a/app/views/components/gds/govuk_wrapper.scala.html
+++ b/app/views/components/gds/govuk_wrapper.scala.html
@@ -47,7 +47,6 @@
       headScripts = None)
     <meta name="format-detection" content="telephone=no" />
     <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/customsdecexfrontend-app.css")' />
-    <script src="@routes.Assets.versioned("javascripts/autocomplete.js")" type="text/javascript"></script>
 
     <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/vendor/jquery-ui.min.css")' type="text/css" >
 }


### PR DESCRIPTION
Still `lib/govuk-frontend/govuk/all.js` is looking for `image` that we don't have in assets folder and some fonts. Don't know how to solve those two problems.

Google tag manager is just line that add this script, but we don't have it, so unnecessary thing.