### PR TITLE
CEDS-2028 Migrate Start page to GDS Design system

### DIFF
--- a/app/assets/stylesheets/customsdecexfrontend-app.scss
+++ b/app/assets/stylesheets/customsdecexfrontend-app.scss
@@ -9,7 +9,6 @@
 
 @import 'partials/_shame';
 
-@import 'lib/govuk-frontend/govuk/all';
 @import 'partials/_step-by-step-navigation';
 @import 'partials/_lists.scss';
 @import 'partials/_layout.scss';
@@ -21,3 +20,4 @@
 $govuk-assets-path: '/customs-movements/assets/';
 $govuk-images-path: "/customs-movements/assets/lib/govuk-frontend/govuk/assets/images/";
 $govuk-fonts-path: "/customs-movements/assets/lib/govuk-frontend/govuk/assets/fonts/";
+@import 'lib/govuk-frontend/govuk/all';

--- a/app/assets/stylesheets/partials/_lists.scss
+++ b/app/assets/stylesheets/partials/_lists.scss
@@ -14,6 +14,7 @@
 
 .dashed-list .dashed-list-item {
   margin-left: 15px;
+  line-height: 1.8em;
 }
 
 /* Prevent nested li's from getting messed up */

--- a/app/views/start_page.scala.html
+++ b/app/views/start_page.scala.html
@@ -14,77 +14,84 @@
  * limitations under the License.
  *@
 
-@import config.AppConfig
 @import views.Title
+@import config.AppConfig
+@import components.gds.gds_main_template
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components.gds._
 
-@this(main_template: views.html.main_template, appConfig: AppConfig)
+@this(  govukLayout: gds_main_template,
+        govukButton: GovukButton,
+        pageTitle: pageTitle,
+        sectionHeader: sectionHeader,
+        appConfig: AppConfig)
 
 @()(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title("startPage.title", Some("startPage.title.sectionHeader"))) {
+@reportLink = {<a class="govuk-link" href="@{appConfig.serviceAvailabilityUrl}">@messages("startPage.problemsWithServiceNotice.link")</a>}
+@beforeYouStartLink = {<a class="govuk-link" href=@{appConfig.customsDeclarationsGoodsTakenOutOfEuUrl}>@messages("startPage.beforeYouStart.line.1.link")</a>}
+@govukLayout(title = Title("startPage.title", Some("startPage.title.sectionHeader")), useCustomContentWidth = true) {
 
-  <div class="grid-row">
-    <div class="column-full">
-      @components.heading(
-        sectionHeader = messages("startPage.title.sectionHeader"),
-        title = messages("startPage.title")
-      )
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            @sectionHeader(messages("startPage.title.sectionHeader"))
+
+            @pageTitle(messages("startPage.title"))
+
+            <p id="description" class="govuk-body-l govuk-!-margin-bottom-8"> @messages("startPage.description") </p>
+
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+        </div>
     </div>
-    <div class="column-full">
-      <p id="description" class="lede">@messages("startPage.description")</p>
+
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h2 id="contents" class="govuk-heading-m">@messages("startPage.contents.header")</h2>
+            <ol id="contents-list" class="dashed-list">
+                <li class="dashed-list-item"><a class="govuk-link" href="#before-you-start">@messages("startPage.beforeYouStart.header")</a></li>
+                <li class="dashed-list-item"><a class="govuk-link" href="#information-you-need">@messages("startPage.informationYouNeed.header")</a></li>
+                <li class="dashed-list-item"><a class="govuk-link" href="#report-your-arrival-and-departure">@messages("startPage.reportYourArrivalAndDeparture.header")</a></li>
+            </ol>
+
+            <h2 class="govuk-heading-m" id="before-you-start">@messages("startPage.beforeYouStart.header")</h2>
+            <p id="before-you-start-element-1" class="govuk-body">@Html(messages("startPage.beforeYouStart.line.1", beforeYouStartLink))</p>
+            <p id="before-you-start-element-2" class="govuk-body">@messages("startPage.beforeYouStart.line.2")</p>
+            <p id="before-you-start-element-3" class="govuk-body govuk-!-margin-bottom-8">@messages("startPage.beforeYouStart.line.3")</p>
+
+
+            <h2 class="govuk-heading-m" id="information-you-need">@messages("startPage.informationYouNeed.header")</h2>
+            <p id="information-you-need-element-1" class="govuk-body">@messages("startPage.informationYouNeed.line.1")</p>
+            <ul id="information-you-need-list" class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
+                <li>@messages("startPage.informationYouNeed.listItem.1")</li>
+                <li>@messages("startPage.informationYouNeed.listItem.2")</li>
+                <li>@messages("startPage.informationYouNeed.listItem.3")</li>
+                <li>@messages("startPage.informationYouNeed.listItem.4")</li>
+            </ul>
+
+
+            <h2 class="govuk-heading-m" id="report-your-arrival-and-departure">@messages("startPage.reportYourArrivalAndDeparture.header")</h2>
+            <div id="problems-with-service-notice" class="govuk-inset-text">@Html(messages("startPage.problemsWithServiceNotice", reportLink))</div>
+
+            @govukButton(Button(
+                href = Some(routes.ChoiceController.displayChoiceForm().url),
+                isStartButton = true,
+                content = Text(messages("startPage.buttonName"))
+            ))
+
+            <div class="app-c-contents-list-with-body__link-wrapper">
+                <div id="back-to-top" class="app-c-contents-list-with-body__link-container">
+                    <a class="govuk-link app-c-back-to-top dont-print" href="#contents">
+                        <svg class="app-c-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+                            <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+                        </svg>
+                        @messages("startPage.contents.header")
+                    </a>
+                </div>
+            </div>
+            <div class="govuk-grid-column-one-third">
+                <div class="gem-c-contextual-sidebar"></div>
+            </div>
+        </div>
     </div>
-  </div>
-
-  <div class="grid-row">
-    <div class="column-full">
-
-      <p id="contents">@messages("startPage.contents.header")</p>
-      <ul id="contents-list" class="dashed-list">
-        <li class="dashed-list-item"><a href="#before-you-start">@messages("startPage.beforeYouStart.header")</a></li>
-        <li class="dashed-list-item"><a href="#information-you-need">@messages("startPage.informationYouNeed.header")</a></li>
-        <li class="dashed-list-item"><a href="#report-your-arrival-and-departure">@messages("startPage.reportYourArrivalAndDeparture.header")</a></li>
-      </ul>
-
-      <h2 id="before-you-start" class="heading-medium">@messages("startPage.beforeYouStart.header")</h2>
-      <p id="before-you-start-element-1">
-        @messages("startPage.beforeYouStart.line.1") <a href=@{appConfig.customsDeclarationsGoodsTakenOutOfEuUrl}>@messages("startPage.beforeYouStart.line.1.link")</a>
-      </p>
-      <p id="before-you-start-element-2">@messages("startPage.beforeYouStart.line.2")</p>
-      <p id="before-you-start-element-3">@messages("startPage.beforeYouStart.line.3")</p>
-
-      <h2 id="information-you-need" class="heading-medium">@messages("startPage.informationYouNeed.header")</h2>
-      <p id="information-you-need-element-1">@messages("startPage.informationYouNeed.line.1")</p>
-      <ul id="information-you-need-list" class="list list-bullet">
-        <li>@messages("startPage.informationYouNeed.listItem.1")</li>
-        <li>@messages("startPage.informationYouNeed.listItem.2")</li>
-        <li>@messages("startPage.informationYouNeed.listItem.3")</li>
-        <li>@messages("startPage.informationYouNeed.listItem.4")</li>
-      </ul>
-
-      <h2 id="report-your-arrival-and-departure" class="heading-medium">@messages("startPage.reportYourArrivalAndDeparture.header")</h2>
-
-      <div class="panel panel-border-wide">
-        <p id="problems-with-service-notice">
-          @messages("startPage.problemsWithServiceNotice") <a href=@{appConfig.serviceAvailabilityUrl}>@messages("startPage.problemsWithServiceNotice.link")</a>
-        </p>
-      </div>
-
-      <br/>
-      <a id="button-start" class="button button-start" href="@routes.ChoiceController.displayChoiceForm" role="button">
-        @messages("startPage.buttonName")
-      </a>
-
-      <div class="mt-5">
-        <p id="back-to-top">
-          <a href="#contents">
-            <svg class="app-c-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
-              <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
-            </svg>
-            @messages("startPage.contents.header")
-          </a>
-        </p>
-      </div>
-
-    </div>
-  </div>
 }

--- a/conf/messages
+++ b/conf/messages
@@ -168,7 +168,7 @@ startPage.title = Tell HMRC when goods you’re exporting arrive at or leave the
 startPage.description = Use the Customs Declaration Service to tell HMRC when the goods you’re exporting out of the EU have arrived at or left the UK port.
 startPage.contents.header = Contents
 startPage.beforeYouStart.header = Before you start
-startPage.beforeYouStart.line.1 = The goods must have already been
+startPage.beforeYouStart.line.1 = The goods must have already been {0}
 startPage.beforeYouStart.line.1.link = declared to customs.
 startPage.beforeYouStart.line.2 = To use this service, you need a Government Gateway user ID and password linked to your EORI number.
 startPage.beforeYouStart.line.3 = If you don’t have a user ID you can get one the first time you make a declaration.
@@ -179,7 +179,7 @@ startPage.informationYouNeed.listItem.2 = the Declaration Unique Consignment Ref
 startPage.informationYouNeed.listItem.3 = the Master Unique Consignment Reference (MUCR) if your goods were consolidated into a bigger consignment
 startPage.informationYouNeed.listItem.4 = details of where you’re sending the export to and from
 startPage.reportYourArrivalAndDeparture.header = Report your arrival and departure
-startPage.problemsWithServiceNotice = Online services may be slow during busy times. Check if there are any
+startPage.problemsWithServiceNotice = Online services may be slow during busy times. Check if there are any {0}
 startPage.problemsWithServiceNotice.link = problems with this service.
 startPage.buttonName = Start now
 

--- a/test/unit/controllers/NotificationsControllerSpec.scala
+++ b/test/unit/controllers/NotificationsControllerSpec.scala
@@ -129,6 +129,14 @@ class NotificationsControllerSpec extends ControllerLayerSpec with ScalaFutures 
 
         status(result) must be(OK)
       }
+
+      "return 200 (OK) with a MUCR Submssion" in {
+        when(connector.fetchSingleSubmission(any(), any())(any()))
+          .thenReturn(Future.successful(Some(exampleSubmission(ucrType = "M"))))
+        val result = controller.listOfNotifications(conversationId)(FakeRequest())
+
+        status(result) must be(OK)
+      }
     }
 
     "submission is missing UCR" should {

--- a/test/unit/views/StartViewSpec.scala
+++ b/test/unit/views/StartViewSpec.scala
@@ -16,15 +16,16 @@
 
 package views
 
+import base.Injector
 import play.twirl.api.Html
 import views.html.start_page
 import views.spec.UnitViewSpec
 import views.tags.ViewTest
 
 @ViewTest
-class StartViewSpec extends UnitViewSpec {
+class StartViewSpec extends UnitViewSpec with Injector {
 
-  private val page = new start_page(mainTemplate, appConfig)
+  private val page = instanceOf[start_page]
   private def createView(): Html = page()(request, messages)
 
   "Start Page view" should {
@@ -91,12 +92,12 @@ class StartViewSpec extends UnitViewSpec {
       view.getElementById("before-you-start").text() mustBe "startPage.beforeYouStart.header"
 
       view.getElementById("before-you-start-element-1").text() must include("startPage.beforeYouStart.line.1")
-      view.getElementById("before-you-start-element-1").text() must include("startPage.beforeYouStart.line.1.link")
       view.getElementById("before-you-start-element-2").text() mustBe "startPage.beforeYouStart.line.2"
       view.getElementById("before-you-start-element-3").text() mustBe "startPage.beforeYouStart.line.3"
     }
 
     "contain link to Customs Declarations Guidance in 'Before you start' section" in {
+      val view = page()(request, messagesApi.preferred(request))
       view.getElementById("before-you-start-element-1").child(0) must haveHref(
         "https://www.gov.uk/guidance/customs-declarations-for-goods-taken-out-of-the-eu"
       )
@@ -122,18 +123,18 @@ class StartViewSpec extends UnitViewSpec {
 
     "display problems with service notice" in {
       view.getElementById("problems-with-service-notice").text() must include("startPage.problemsWithServiceNotice")
-      view.getElementById("problems-with-service-notice").text() must include("startPage.problemsWithServiceNotice.link")
     }
 
     "contain link to service availability in 'Report your arrival and departure' section" in {
+      val view = page()(request, messagesApi.preferred(request))
       view.getElementById("problems-with-service-notice").child(0) must haveHref(
         "https://www.gov.uk/guidance/customs-declaration-service-service-availability-and-issues"
       )
     }
 
     "display 'Start now' button" in {
-      view.getElementById("button-start").text() mustBe "startPage.buttonName"
-      view.getElementById("button-start") must haveHref(controllers.routes.ChoiceController.displayChoiceForm())
+      view.getElementsByClass("govuk-button govuk-button--start").get(0).text() mustBe "startPage.buttonName"
+      view.getElementsByClass("govuk-button govuk-button--start").get(0) must haveHref(controllers.routes.ChoiceController.displayChoiceForm())
     }
 
     "display link to go back to Contents section" in {

--- a/test/unit/views/StartViewSpec.scala
+++ b/test/unit/views/StartViewSpec.scala
@@ -142,5 +142,4 @@ class StartViewSpec extends UnitViewSpec with Injector {
       view.getElementById("back-to-top").child(0) must haveHref("#contents")
     }
   }
-
 }


### PR DESCRIPTION
**WORK DONE:**

 * **Migrate Start page to GDS Design system**
As part of this work, we kept looking at the prototype, unfortunately 
how the Start page was designed in the prototype it composed of several
`govuk-grid-column-two-thirds` plus some `govuk-grid-column-one-third`.
Since the start page is not a critical page to the service, we have
brought it to the GDS design system, but kept the same layout as before.
Also the Dashed list does not exist as a component in the GDS design
system, so again, we have kept the same approach as before, by simply
using the a normal dash.

* **Import govuk-frontend/govuk assets as the last task**
In order to access all assets and load them correctly, the
`govuk-frontend/govuk` has to be the last imported library in this file.
This actually fixes the problem of not finding the correct fonts for our
Movements FE service, after we migrated to the GDS design system.