### PR TITLE
CEDS-2028 Add govukFlexibleLayout

### DIFF
--- a/app/views/components/gds/gds_main_template.scala.html
+++ b/app/views/components/gds/gds_main_template.scala.html
@@ -34,7 +34,7 @@
 @(
   title: Title,
   backButton: Option[BackButton] = None,
-  useDefaultContentWidth: Boolean = true
+  useCustomContentWidth: Boolean = false
 )(contentBlock: Html)(implicit request: Request[_], messages: Messages)
 
 @head = {
@@ -76,8 +76,8 @@
         FooterItem(href = Some("help"), text = Some("Help using GOV.UK"))
     )}
 
-@if(useDefaultContentWidth) {
-  @govukLayout(
+@if(useCustomContentWidth) {
+  @govukFlexibleLayout(
     pageTitle = Some(title.format),
     headBlock = Some(head),
     beforeContentBlock = Some(beforeContentBlock),
@@ -87,7 +87,7 @@
     footerItems = footer
   )(contentBlock)
 } else {
-  @govukFlexibleLayout(
+  @govukLayout(
     pageTitle = Some(title.format),
     headBlock = Some(head),
     beforeContentBlock = Some(beforeContentBlock),

--- a/app/views/components/gds/gds_main_template.scala.html
+++ b/app/views/components/gds/gds_main_template.scala.html
@@ -19,18 +19,23 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 @import views.Title
 @import views.components.BackButton
+@import views.html.components.gds.govukFlexibleLayout
 
 @this(
   govukHeader: GovukHeader,
   govukLayout: GovukLayout,
+  govukFlexibleLayout: govukFlexibleLayout,
   govukPhaseBanner: GovukPhaseBanner,
   govukBackLink: GovukBackLink,
   siteHeader: siteHeader,
   phaseBanner: phaseBanner
 )
 
-@(  title: Title,
-    backButton: Option[BackButton] = None)(contentBlock: Html)(implicit request: Request[_], messages: Messages)
+@(
+  title: Title,
+  backButton: Option[BackButton] = None,
+  useDefaultContentWidth: Boolean = true
+)(contentBlock: Html)(implicit request: Request[_], messages: Messages)
 
 @head = {
     <link rel="shortcut icon" href='@routes.Assets.versioned("/lib/govuk-frontend/govuk/assets/images/favicon.ico")' type="image/x-icon" />
@@ -71,7 +76,8 @@
         FooterItem(href = Some("help"), text = Some("Help using GOV.UK"))
     )}
 
-@govukLayout(
+@if(useDefaultContentWidth) {
+  @govukLayout(
     pageTitle = Some(title.format),
     headBlock = Some(head),
     beforeContentBlock = Some(beforeContentBlock),
@@ -79,4 +85,15 @@
     scriptsBlock = Some(scripts),
     headerBlock = Some(siteHeader()),
     footerItems = footer
-)(contentBlock)
+  )(contentBlock)
+} else {
+  @govukFlexibleLayout(
+    pageTitle = Some(title.format),
+    headBlock = Some(head),
+    beforeContentBlock = Some(beforeContentBlock),
+    bodyEndBlock = None,
+    scriptsBlock = Some(scripts),
+    headerBlock = Some(siteHeader()),
+    footerItems = footer
+  )(contentBlock)
+}

--- a/app/views/components/gds/govukFlexibleLayout.scala.html
+++ b/app/views/components/gds/govukFlexibleLayout.scala.html
@@ -1,0 +1,67 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
+@this(
+  govukTemplate: GovukTemplate,
+  govukHeader: GovukHeader,
+  govukFooter: GovukFooter,
+  govukBackLink: GovukBackLink
+)
+
+@(
+  pageTitle: Option[String] = None,
+  headBlock: Option[Html] = None,
+  headerBlock: Option[Html] = None,
+  beforeContentBlock: Option[Html] = None,
+  footerBlock: Option[Html] = None,
+  footerItems: Seq[FooterItem] = Seq.empty,
+  bodyEndBlock: Option[Html] = None,
+  scriptsBlock: Option[Html] = None
+)(contentBlock: Html)(implicit request: Request[_], messages: Messages)
+
+@headerDefault = {
+  @headerBlock.getOrElse {
+    @govukHeader(Header(
+      homepageUrl = Some(messages("service.homePageUrl")),
+      serviceName = Some(messages("service.name")),
+      serviceUrl = Some(messages("service.homePageUrl")),
+      containerClasses = Some("govuk-width-container")))
+  }
+}
+
+@footerDefault = {
+  @footerBlock.getOrElse {
+    @govukFooter(new Footer(meta = Some(Meta(items = Some(footerItems)))))
+  }
+}
+
+@bodyEndDefault = {
+  @bodyEndBlock
+  @scriptsBlock
+}
+
+@govukTemplate(
+  htmlLang = Some("en"),
+  pageTitle = pageTitle,
+  headBlock = headBlock,
+  headerBlock = headerDefault,
+  beforeContentBlock = beforeContentBlock,
+  footerBlock = footerDefault,
+  mainClasses = Some("govuk-main-wrapper--auto-spacing"),
+  bodyEndBlock = Some(bodyEndDefault)
+)(contentBlock)


### PR DESCRIPTION
The default govukLayout provided by play-frontend-govuk does not allow
for customizable page content width. Everything is encapsulated in
govuk-grid-column-two-thirds element.

The new component is a copy of the library's govukLayout but it is
passing the content as is, without adding wrapping elements.
The responsibility for this is moved to the client.

To choose new layout component you have to set useDefaultContentWidth to
false in gds_main_template.