### PR TITLE
Confirmation page flash keys usage

### DIFF
--- a/app/controllers/consolidations/AssociateUcrConfirmationController.scala
+++ b/app/controllers/consolidations/AssociateUcrConfirmationController.scala
@@ -16,8 +16,10 @@
 
 package controllers.consolidations
 
-import controllers.actions.{AuthAction}
+import controllers.actions.AuthAction
+import controllers.storage.FlashKeys
 import javax.inject.{Inject, Singleton}
+import models.ReturnToStartException
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -31,6 +33,8 @@ class AssociateUcrConfirmationController @Inject()(
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] = authenticate { implicit request =>
-    Ok(associateDucrConfirmPage())
+    val kind: String = request.flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse(throw ReturnToStartException)
+    val ucr: String = request.flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
+    Ok(associateDucrConfirmPage(kind, ucr))
   }
 }

--- a/app/controllers/consolidations/DisassociateUcrConfirmationController.scala
+++ b/app/controllers/consolidations/DisassociateUcrConfirmationController.scala
@@ -17,7 +17,9 @@
 package controllers.consolidations
 
 import controllers.actions.AuthAction
+import controllers.storage.FlashKeys
 import javax.inject.{Inject, Singleton}
+import models.ReturnToStartException
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -34,6 +36,8 @@ class DisassociateUcrConfirmationController @Inject()(
     extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] = authenticate { implicit request =>
-    Ok(disassociateUcrConfirmationPage())
+    val kind: String = request.flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse(throw ReturnToStartException)
+    val ucr: String = request.flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
+    Ok(disassociateUcrConfirmationPage(kind, ucr))
   }
 }

--- a/app/controllers/consolidations/ShutMucrConfirmationController.scala
+++ b/app/controllers/consolidations/ShutMucrConfirmationController.scala
@@ -17,7 +17,9 @@
 package controllers.consolidations
 
 import controllers.actions.AuthAction
+import controllers.storage.FlashKeys
 import javax.inject.{Inject, Singleton}
+import models.ReturnToStartException
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -34,6 +36,7 @@ class ShutMucrConfirmationController @Inject()(
     extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] = authenticate { implicit request =>
-    Ok(shutMucrConfirmationPage())
+    val mucr: String = request.flash.get(FlashKeys.MUCR).getOrElse(throw ReturnToStartException)
+    Ok(shutMucrConfirmationPage(mucr))
   }
 }

--- a/app/views/associate_ucr_confirmation.scala.html
+++ b/app/views/associate_ucr_confirmation.scala.html
@@ -26,16 +26,16 @@
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
-@()(implicit request: Request[_], flash: Flash, messages: Messages)
+@(kind: String, ucr: String)(implicit request: Request[_], messages: Messages)
 
-@prefix = @{ s"associate.${flash(FlashKeys.CONSOLIDATION_KIND)}.confirmation" }
+@prefix = @{ s"associate.$kind.confirmation" }
 @associateLink = {@components.gds.link(messages("association.confirmation.associateOrShut.associate"), routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR.value))}
 @shutMucrLink = {@components.gds.link(messages("association.confirmation.associateOrShut.shut"), routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR.value))}
 
 @govukLayout(title = Title(s"${prefix}.tab.heading")) {
 
     @govukPanel(Panel(
-        title = Text(messages(s"${prefix}.heading", flash.get(FlashKeys.UCR).getOrElse("-")))
+        title = Text(messages(s"${prefix}.heading", ucr))
     ))
 
     @components.confirmation_status_info()

--- a/app/views/disassociate_ucr_confirmation.scala.html
+++ b/app/views/disassociate_ucr_confirmation.scala.html
@@ -26,16 +26,15 @@
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
-@()(implicit request: Request[_], flash: Flash, messages: Messages)
+@(kind: String, ucr: String)(implicit request: Request[_], messages: Messages)
 
 @associateLink = {@components.gds.link(messages("disassociation.confirmation.associateOrShut.associate"), routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR.value))}
 @shutMucrLink = {@components.gds.link(messages("disassociation.confirmation.associateOrShut.shut"), routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR.value))}
-@kind = @{flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse("")}
 
 @govukLayout(title = Title(s"disassociate.ucr.confirmation.$kind.title")) {
 
     @govukPanel(Panel(
-        title = Text(messages("disassociate.ucr.confirmation.heading", kind, flash.get(FlashKeys.UCR).getOrElse("-")))
+        title = Text(messages("disassociate.ucr.confirmation.heading", kind, ucr))
     ))
 
     @components.confirmation_status_info()

--- a/app/views/shut_mucr_confirmation.scala.html
+++ b/app/views/shut_mucr_confirmation.scala.html
@@ -26,7 +26,7 @@
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
-@()(implicit request: Request[_], flash: Flash, messages: Messages)
+@(mucr: String)(implicit request: Request[_], messages: Messages)
 
 @shutMucrLink = {@components.gds.link(messages("shutMucr.confirmation.nextSteps.shutMucr"), routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR.value))}
 @departureLink = {@components.gds.link(messages("shutMucr.confirmation.nextSteps.depart"), routes.ChoiceController.startSpecificJourney(forms.Choice.Departure.value))}
@@ -34,7 +34,7 @@
 @govukLayout(title = Title("shutMucr.confirmation.tab.heading")) {
 
     @govukPanel(Panel(
-        title = Text(messages("shutMucr.confirmation.heading", flash.get(FlashKeys.MUCR).getOrElse("-")))
+        title = Text(messages("shutMucr.confirmation.heading", mucr))
     ))
 
     @components.confirmation_status_info()

--- a/test/unit/controllers/consolidations/AssociateUcrConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUcrConfirmationControllerSpec.scala
@@ -17,8 +17,12 @@
 package unit.controllers.consolidations
 
 import controllers.consolidations.AssociateUcrConfirmationController
+import controllers.storage.FlashKeys
+import models.ReturnToStartException
+import models.cache.JourneyType
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify, when}
+import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import unit.controllers.ControllerLayerSpec
@@ -33,7 +37,7 @@ class AssociateUcrConfirmationControllerSpec extends ControllerLayerSpec {
 
   override def beforeEach() {
     super.beforeEach()
-    when(page.apply()(any(), any(), any())).thenReturn(HtmlFormat.empty)
+    when(page.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 
   override def afterEach(): Unit = {
@@ -43,14 +47,29 @@ class AssociateUcrConfirmationControllerSpec extends ControllerLayerSpec {
   }
 
   "Associate DUCR Confirmation controller" should {
+    implicit val get = FakeRequest("GET", "/")
 
     "return 200 (OK)" when {
 
       "display page method is invoked" in {
-        val result = controller.displayPage()(getRequest())
+        val result = controller.displayPage()(get.withFlash(FlashKeys.CONSOLIDATION_KIND -> "kind", FlashKeys.UCR -> "123"))
 
         status(result) must be(OK)
-        verify(page).apply()(any(), any(), any())
+        verify(page).apply(any(), any())(any(), any())
+      }
+    }
+
+    "return to start" when {
+      "ucr kind is missing" in {
+        intercept[RuntimeException] {
+          await(controller.displayPage()(get.withFlash(FlashKeys.UCR -> "123")))
+        } mustBe ReturnToStartException
+      }
+
+      "ucr is missing" in {
+        intercept[RuntimeException] {
+          await(controller.displayPage()(get.withFlash(FlashKeys.CONSOLIDATION_KIND -> "kind")))
+        } mustBe ReturnToStartException
       }
     }
   }

--- a/test/unit/controllers/consolidations/ShutMucrConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/ShutMucrConfirmationControllerSpec.scala
@@ -17,8 +17,11 @@
 package unit.controllers.consolidations
 
 import controllers.consolidations.ShutMucrConfirmationController
+import controllers.storage.FlashKeys
+import models.ReturnToStartException
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
+import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import unit.controllers.ControllerLayerSpec
@@ -35,19 +38,28 @@ class ShutMucrConfirmationControllerSpec extends ControllerLayerSpec {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    when(mockShutMucrConfirmationPage.apply()(any(), any(), any())).thenReturn(HtmlFormat.empty)
+    when(mockShutMucrConfirmationPage.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 
   "Shut Mucr Confirmation Controller" should {
+    implicit val get = FakeRequest("GET", "/")
 
     "return 200 (OK)" when {
 
       "display page is invoked" in {
 
-        val result = controller.displayPage()(getRequest())
+        val result = controller.displayPage()(get.withFlash(FlashKeys.MUCR -> "123"))
 
         status(result) mustBe OK
-        verify(mockShutMucrConfirmationPage).apply()(any(), any(), any())
+        verify(mockShutMucrConfirmationPage).apply(any())(any(), any())
+      }
+    }
+
+    "return to start" when {
+      "mucr is missing" in {
+        intercept[RuntimeException] {
+          await(controller.displayPage()(get.withFlash()))
+        } mustBe ReturnToStartException
       }
     }
   }

--- a/test/unit/views/AssociateDucrConfirmationViewSpec.scala
+++ b/test/unit/views/AssociateDucrConfirmationViewSpec.scala
@@ -18,9 +18,7 @@ package views
 
 import base.Injector
 import controllers.routes
-import controllers.storage.FlashKeys
 import models.cache.AssociateUcrAnswers
-import play.api.mvc.Flash
 import play.twirl.api.Html
 import testdata.CommonTestData.correctUcr
 import views.html.associate_ucr_confirmation
@@ -32,7 +30,7 @@ class AssociateDucrConfirmationViewSpec extends ViewSpec with Injector {
   private implicit val request = journeyRequest(AssociateUcrAnswers())
   private val page = instanceOf[associate_ucr_confirmation]
 
-  private val view: Html = page()(request, new Flash(Map(FlashKeys.CONSOLIDATION_KIND -> "ducr", FlashKeys.UCR -> correctUcr)), messages)
+  private val view: Html = page("ducr", correctUcr)(request, messages)
 
   "Associate Ducr Confirmation View" should {
 

--- a/test/unit/views/DisassociateUcrConfirmationViewSpec.scala
+++ b/test/unit/views/DisassociateUcrConfirmationViewSpec.scala
@@ -18,9 +18,7 @@ package views
 
 import base.Injector
 import controllers.routes
-import controllers.storage.FlashKeys
 import models.cache.DisassociateUcrAnswers
-import play.api.mvc.Flash
 import play.twirl.api.Html
 import testdata.CommonTestData.correctUcr
 import views.html.disassociate_ucr_confirmation
@@ -32,7 +30,7 @@ class DisassociateUcrConfirmationViewSpec extends ViewSpec with Injector {
   private implicit val request = journeyRequest(DisassociateUcrAnswers())
   private val page = instanceOf[disassociate_ucr_confirmation]
   private val view: Html =
-    page()(request, new Flash(Map(FlashKeys.UCR -> correctUcr, FlashKeys.CONSOLIDATION_KIND -> "DUCR")), messages)
+    page("DUCR", correctUcr)(request, messages)
 
   "Disassociate Ucr Confirmation View" should {
 

--- a/test/unit/views/ShutMucrConfirmationViewSpec.scala
+++ b/test/unit/views/ShutMucrConfirmationViewSpec.scala
@@ -18,9 +18,7 @@ package views
 
 import base.Injector
 import controllers.routes
-import controllers.storage.FlashKeys
 import models.cache.ShutMucrAnswers
-import play.api.mvc.Flash
 import play.twirl.api.Html
 import testdata.CommonTestData.correctUcr
 import views.html.shut_mucr_confirmation
@@ -31,7 +29,7 @@ class ShutMucrConfirmationViewSpec extends ViewSpec with Injector {
 
   private implicit val request = journeyRequest(ShutMucrAnswers())
   private val shutMucrConformationPage = instanceOf[shut_mucr_confirmation]
-  private val view: Html = shutMucrConformationPage()(request, Flash(Map(FlashKeys.MUCR -> correctUcr)), messages)
+  private val view: Html = shutMucrConformationPage(correctUcr)(request, messages)
 
   "Shut Mucr Confirmation View" should {
 


### PR DESCRIPTION
During testing I noticed that one of the confirmation pages blew up when pressing refresh (due to a missing Flash key).

This PR is to standardise the way Flash keys are used (to be the same as MovementConfirmationController) whereby the key values are extracted by the controller and passed to the page.  Missing key/value results in a "ReturnToStart" exception.