### PR TITLE
Update dependencies

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,19 +6,19 @@ object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc"          %% "play-conditional-form-mapping" % "1.1.0-play-26",
+    "uk.gov.hmrc"          %% "play-conditional-form-mapping" % "1.2.0-play-26",
     "uk.gov.hmrc"          %% "logback-json-logger"           % "4.6.0",
-    "uk.gov.hmrc"          %% "govuk-template"                % "5.38.0-play-26",
+    "uk.gov.hmrc"          %% "govuk-template"                % "5.48.0-play-26",
     "uk.gov.hmrc"          %% "play-health"                   % "3.14.0-play-26",
     "uk.gov.hmrc"          %% "play-ui"                       % "8.5.0-play-26",
-    "uk.gov.hmrc"          %% "bootstrap-play-26"             % "0.46.0",
-    "uk.gov.hmrc"          %% "play-frontend-govuk"           % "0.30.0-play-26",
+    "uk.gov.hmrc"          %% "bootstrap-play-26"             % "1.3.0",
+    "uk.gov.hmrc"          %% "play-frontend-govuk"           % "0.32.0-play-26",
     "org.webjars.npm"      %  "govuk-frontend"                % "3.4.0",
     "ai.x"                 %% "play-json-extensions"          % "0.40.2",
     "uk.gov.hmrc"          %% "play-whitelist-filter"         % "3.1.0-play-26",
     "uk.gov.hmrc"          %% "simple-reactivemongo"          % "7.22.0-play-26",
-    "uk.gov.hmrc"          %% "wco-dec"                       % "0.31.0",
-    "uk.gov.hmrc"          %% "play-json-union-formatter"     % "1.5.0",
+    "uk.gov.hmrc"          %% "wco-dec"                       % "0.33.0",
+    "uk.gov.hmrc"          %% "play-json-union-formatter"     % "1.7.0",
     "com.github.tototoshi" %% "scala-csv"                     % "1.3.6"
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.3.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.4.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
@@ -12,7 +12,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.3")
 


### PR DESCRIPTION
We're not able to use the newest version of sbt-plugin. Version 2.6.24 use akka version 2.5.25.
The last akka version that is compatible with reactive mongo is 2.5.23.
This is the reason that we need to use sbt-plugin 2.6.23.