### PR TITLE
CEDS-2029 Force use of commons-codec v1.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val microservice = Project(appName, file("."))
   .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory, SbtWeb)
   .settings(
     libraryDependencies ++= AppDependencies(),
+    dependencyOverrides += "commons-codec" % "commons-codec" % "1.12",
     retrieveManaged := true,
     evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
     majorVersion := 0,


### PR DESCRIPTION
This is due to a failed deployment to `externaltest` environement where
an error was found:

```
java.lang.IllegalArgumentException: Last encoded character (before the
paddings if any) is a valid base 64 alphabet but not a possible value
```

This is to do with an incorrect sso encryption key being used in
externaltest and the latest version of `simple-reactivemongo` uses the
latest `commons-codec v1.13` which detects this as an issue and the
deployment fails.
This has been discussed with Colin Webb and Lewis Capaldi.

This is the last resort attempt to deploy the applications to
`externaltest` whilst HMRC Platform team look into the issue.