### PR TITLE
CEDS-2164 - add TTL of 60 mins to cache

### DIFF
--- a/app/mongobee/changesets/CacheChangelog.java
+++ b/app/mongobee/changesets/CacheChangelog.java
@@ -18,7 +18,16 @@ package mongobee.changesets;
 
 import com.github.mongobee.changeset.ChangeLog;
 import com.github.mongobee.changeset.ChangeSet;
+import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import org.bson.Document;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 @ChangeLog
 public class CacheChangelog {
@@ -26,5 +35,16 @@ public class CacheChangelog {
 
     @ChangeSet(order = "001", id = "External Movements DB Baseline", author = "Paulo Monteiro")
     public void dbBaseline(DB db) {
+    }
+
+    @ChangeSet(order = "002", id = "Add 'updated' field to cache and ttl of 60 mins", author = "Steve Sugden")
+    public void addCacheUpdateField(MongoDatabase db) {
+
+        Document query = new Document();
+        Document update = new Document("$set", new Document("updated", Date.from(Instant.now())));
+        db.getCollection(collection).updateMany(new BasicDBObject(query), new BasicDBObject(update));
+
+        IndexOptions options = new IndexOptions().expireAfter(60L, TimeUnit.MINUTES).name("ttl");
+        db.getCollection(collection).createIndex(Indexes.ascending("updated"), options);
     }
 }


### PR DESCRIPTION
- added new "updated" field to cache model with default of "now"
- updated the db (using Mongobee) to add field to existing cache objects and add ttl index to cache collection

