### PR TITLE
CEDS-2164 - make 'updated' field optional.

### DIFF
--- a/app/models/cache/Cache.scala
+++ b/app/models/cache/Cache.scala
@@ -20,7 +20,7 @@ import java.time.{Instant, ZoneOffset}
 
 import play.api.libs.json._
 
-case class Cache(eori: String, answers: Answers, updated: Instant = Instant.now())
+case class Cache(eori: String, answers: Answers, updated: Option[Instant] = Some(Instant.now()))
 
 object Cache {
   implicit private val formatInstant: OFormat[Instant] = new OFormat[Instant] {


### PR DESCRIPTION
Exising cache data cannot be migrated and we can't manually drop db in
prod., so new fields have to be optional.