### PR TITLE
CEDS-2174 - Pre-populate UCR in Movements journeys

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -114,4 +114,10 @@ class AppConfig @Inject()(
 
   private def str2FeatureStatus(str: String): FeatureStatus =
     FeatureStatus.withName(str)
+
+  private def featureSwitch(key: String): Boolean =
+    runModeConfiguration.getOptional[Boolean](s"featureSwitches.$key").getOrElse(false)
+
+  lazy val hasQueryUcrFeature: Boolean = featureSwitch("queryUcrEnabled")
+
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -146,3 +146,9 @@ urls {
   customsDeclarationsGoodsTakenOutOfEu = "https://www.gov.uk/guidance/customs-declarations-for-goods-taken-out-of-the-eu"
   serviceAvailability = "https://www.gov.uk/guidance/customs-declaration-service-service-availability-and-issues"
 }
+
+featureSwitches {
+  featureSwitches {
+    queryUcrEnabled = true
+  }
+}


### PR DESCRIPTION
When the user has searched for an UCR, and then wants to perform an action on it, they should not have to re-enter it.

To achieve this, it is required to:

1) create the ability to set/reset feature flags(*), -- ok
2) expose an optional query-ucr parameter in the cache, -- pending
3) update views to display the ucr appropriately. -- pending

(*) there is already an implementation for feature flags that seems inadequate/unused - check for removal later.