### PR TITLE
CEDS-2057 - Rename the Export services

### DIFF
--- a/app/views/components/gds/siteHeader.scala.html
+++ b/app/views/components/gds/siteHeader.scala.html
@@ -23,7 +23,7 @@
 
 @govukHeader(Header(
     homepageUrl = None,
-    serviceName = Some(messages("site.service_name")),
+    serviceName = Some(messages("service.name")),
     serviceUrl = None,
     containerClasses = Some("govuk-width-container"),
     navigation = None

--- a/conf/messages
+++ b/conf/messages
@@ -52,7 +52,6 @@ site.continue = Continue
 site.acceptAndSend = Accept and send
 site.confirmAndSubmit = Confirm and submit
 site.save_and_come_back_later = Save and come back later
-site.service_name = Declare an Export
 site.textarea.char_limit = (Limit is {0} characters)
 site.submit = Submit
 site.backToStart = Back to start

--- a/test/unit/views/components/SiteHeaderSpec.scala
+++ b/test/unit/views/components/SiteHeaderSpec.scala
@@ -1,0 +1,24 @@
+package views.components
+
+import base.Injector
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import views.ViewSpec
+import views.html.components.gds.siteHeader
+
+class SiteHeaderSpec extends ViewSpec with Injector {
+
+  private val page = instanceOf[siteHeader]
+  private implicit val request = FakeRequest()
+
+  private def createHeader(): Html = page()(request, messages)
+
+  "Site header" should {
+    val siteHeader = createHeader()
+
+    "display banner with the service name" in {
+      siteHeader.getElementsByClass("govuk-header__link govuk-header__link--service-name").first() must containMessage("service.name")
+    }
+
+  }
+}


### PR DESCRIPTION
Fix banners.

A consistent naming convention must be displayed across all three CDS Exports services to provide users for a simplified experience and understanding.

The CDS Movements Exports service was modified to:

1) the service name changed to CDS Exports in the banners at the top of each page,
2) the service name changed to CDS Exports on the start page.