### PR TITLE
CEDS-2201 - Prevent changes to UCR when Associating

### DIFF
--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -88,13 +88,18 @@ class ChoiceController @Inject()(
       if (appConfig.ileQueryEnabled) controllers.consolidations.routes.ShutMucrSummaryController.displayPage()
       else consolidations.routes.ShutMucrController.displayPage()
 
+    def associateFirstPage =
+      if (appConfig.ileQueryEnabled)
+        consolidations.routes.ManageMucrController.displayPage()
+      else consolidations.routes.MucrOptionsController.displayPage()
+
     (choice match {
       case Arrival =>
         createOrUpdateCache(request.eori, ArrivalAnswers.fromUcr).map(_ => movementFirstPage)
       case Departure =>
         createOrUpdateCache(request.eori, DepartureAnswers.fromUcr).map(_ => movementFirstPage)
       case AssociateUCR =>
-        createOrUpdateCache(request.eori, AssociateUcrAnswers.fromUcr).map(_ => consolidations.routes.MucrOptionsController.displayPage())
+        createOrUpdateCache(request.eori, AssociateUcrAnswers.fromUcr).map(_ => associateFirstPage)
       case DisassociateUCR =>
         createOrUpdateCache(request.eori, DisassociateUcrAnswers.fromUcr).map(_ => dissociateFirstPage)
       case ShutMUCR =>

--- a/app/controllers/consolidations/AssociateUcrSummaryController.scala
+++ b/app/controllers/consolidations/AssociateUcrSummaryController.scala
@@ -16,8 +16,10 @@
 
 package controllers.consolidations
 
+import config.AppConfig
 import controllers.actions.{AuthAction, JourneyRefiner}
 import controllers.storage.FlashKeys
+import forms.{AssociateKind, ManageMucrChoice}
 import javax.inject.{Inject, Singleton}
 import models.ReturnToStartException
 import models.cache.{AssociateUcrAnswers, JourneyType}
@@ -25,7 +27,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc._
 import services.SubmissionService
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-import views.html.associateucr.associate_ucr_summary
+import views.html.associateucr.{associate_ucr_summary, associate_ucr_summary_no_change}
 
 import scala.concurrent.ExecutionContext
 
@@ -35,15 +37,26 @@ class AssociateUcrSummaryController @Inject()(
   journeyType: JourneyRefiner,
   mcc: MessagesControllerComponents,
   submissionService: SubmissionService,
-  associateUcrSummaryPage: associate_ucr_summary
+  appConfig: AppConfig,
+  associateUcrSummaryPage: associate_ucr_summary,
+  associateUcrSummaryNoChangePage: associate_ucr_summary_no_change
 )(implicit executionContext: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType(JourneyType.ASSOCIATE_UCR)) { implicit request =>
     val answers = request.answersAs[AssociateUcrAnswers]
     val mucrOptions = answers.mucrOptions.getOrElse(throw ReturnToStartException)
-    val ucr = answers.associateUcr.getOrElse(throw ReturnToStartException)
-    Ok(associateUcrSummaryPage(ucr, mucrOptions.mucr))
+    val associateUcr = answers.associateUcr.getOrElse(throw ReturnToStartException)
+
+    if (appConfig.ileQueryEnabled) {
+      val associateAnotherMucr = answers.manageMucrChoice.exists(_.choice == ManageMucrChoice.AssociateAnotherMucr)
+      if (associateAnotherMucr)
+        Ok(associateUcrSummaryNoChangePage(mucrOptions.mucr, associateUcr.ucr, associateUcr.kind, answers.manageMucrChoice))
+      else
+        Ok(associateUcrSummaryNoChangePage(associateUcr.ucr, mucrOptions.mucr, AssociateKind.Mucr, answers.manageMucrChoice))
+    } else
+      Ok(associateUcrSummaryPage(associateUcr, mucrOptions.mucr))
+
   }
 
   def submit(): Action[AnyContent] = (authenticate andThen journeyType(JourneyType.ASSOCIATE_UCR)).async { implicit request =>

--- a/app/controllers/consolidations/AssociateUcrSummaryController.scala
+++ b/app/controllers/consolidations/AssociateUcrSummaryController.scala
@@ -19,7 +19,7 @@ package controllers.consolidations
 import config.AppConfig
 import controllers.actions.{AuthAction, JourneyRefiner}
 import controllers.storage.FlashKeys
-import forms.{AssociateKind, ManageMucrChoice}
+import forms.AssociateKind
 import javax.inject.{Inject, Singleton}
 import models.ReturnToStartException
 import models.cache.{AssociateUcrAnswers, JourneyType}
@@ -49,8 +49,7 @@ class AssociateUcrSummaryController @Inject()(
     val associateUcr = answers.associateUcr.getOrElse(throw ReturnToStartException)
 
     if (appConfig.ileQueryEnabled) {
-      val associateAnotherMucr = answers.manageMucrChoice.exists(_.choice == ManageMucrChoice.AssociateAnotherMucr)
-      if (associateAnotherMucr)
+      if (answers.isAssociateAnotherMucr)
         Ok(associateUcrSummaryNoChangePage(mucrOptions.mucr, associateUcr.ucr, associateUcr.kind, answers.manageMucrChoice))
       else
         Ok(associateUcrSummaryNoChangePage(associateUcr.ucr, mucrOptions.mucr, AssociateKind.Mucr, answers.manageMucrChoice))

--- a/app/controllers/consolidations/ManageMucrController.scala
+++ b/app/controllers/consolidations/ManageMucrController.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.consolidations
+
+import controllers.actions.{AuthAction, IleQueryAction, JourneyRefiner}
+import controllers.consolidations
+import controllers.exception.InvalidFeatureStateException
+import forms.ManageMucrChoice.{form, AssociateAnotherMucr, AssociateThisMucr}
+import forms.{AssociateUcr, MucrOptions, UcrType}
+import javax.inject.{Inject, Singleton}
+import models.cache.{AssociateUcrAnswers, JourneyType}
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.CacheRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.html.associateucr.manage_mucr
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ManageMucrController @Inject()(
+  authenticate: AuthAction,
+  ileQueryFeatureEnabled: IleQueryAction,
+  getJourney: JourneyRefiner,
+  mcc: MessagesControllerComponents,
+  cacheRepository: CacheRepository,
+  page: manage_mucr
+)(implicit ec: ExecutionContext)
+    extends FrontendController(mcc) with I18nSupport {
+
+  def displayPage(): Action[AnyContent] = (authenticate andThen ileQueryFeatureEnabled andThen getJourney(JourneyType.ASSOCIATE_UCR)) {
+    implicit request =>
+      if (request.cache.queryUcr.map(_.is(UcrType.Ducr)).getOrElse(throw InvalidFeatureStateException)) {
+        Redirect(consolidations.routes.MucrOptionsController.displayPage())
+      } else {
+        val mucrOptions = request.answersAs[AssociateUcrAnswers].manageMucrChoice
+        Ok(page(mucrOptions.fold(form)(form.fill), request.cache.queryUcr))
+      }
+  }
+
+  def submit(): Action[AnyContent] = (authenticate andThen ileQueryFeatureEnabled andThen getJourney(JourneyType.ASSOCIATE_UCR)).async {
+    implicit request =>
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(page(formWithErrors, request.cache.queryUcr))),
+          validForm => {
+            val answers = request.answersAs[AssociateUcrAnswers]
+            val previousManageMucrChoice = answers.manageMucrChoice
+            val newManageMucrChoice = Some(validForm)
+            val updatedAnswers = answers.copy(manageMucrChoice = newManageMucrChoice)
+            validForm.choice match {
+              case AssociateThisMucr => {
+                // Here we need to create AssociateUCR from query and clear MucrOptions if ManageMucrChoice has changed
+                val updatedForAssociateThisMucr =
+                  if (newManageMucrChoice == previousManageMucrChoice) updatedAnswers
+                  else
+                    updatedAnswers
+                      .copy(associateUcr = request.cache.queryUcr.map(AssociateUcr.apply), mucrOptions = None)
+                cacheRepository.upsert(request.cache.update(updatedForAssociateThisMucr)).map { _ =>
+                  Redirect(routes.MucrOptionsController.displayPage())
+                }
+              }
+              case AssociateAnotherMucr => {
+                // Here we need to clear AssociateUCR and create MucrOptions from query if ManageMucrChoice has changed
+                val updatedForAssociateAnotherMucr =
+                  if (newManageMucrChoice == previousManageMucrChoice) updatedAnswers
+                  else
+                    updatedAnswers
+                      .copy(associateUcr = None, mucrOptions = request.cache.queryUcr.map(MucrOptions.apply))
+                cacheRepository.upsert(request.cache.update(updatedForAssociateAnotherMucr)).map { _ =>
+                  Redirect(routes.AssociateUcrController.displayPage())
+                }
+              }
+            }
+          }
+        )
+  }
+}

--- a/app/controllers/consolidations/MucrOptionsController.scala
+++ b/app/controllers/consolidations/MucrOptionsController.scala
@@ -16,11 +16,12 @@
 
 package controllers.consolidations
 
+import config.AppConfig
 import controllers.actions.{AuthAction, JourneyRefiner}
 import forms.MucrOptions
 import forms.MucrOptions.form
 import javax.inject.{Inject, Singleton}
-import models.cache.{AssociateUcrAnswers, Cache, JourneyType}
+import models.cache.{AssociateUcrAnswers, JourneyType}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.CacheRepository
@@ -35,28 +36,32 @@ class MucrOptionsController @Inject()(
   getJourney: JourneyRefiner,
   mcc: MessagesControllerComponents,
   cacheRepository: CacheRepository,
+  appConfig: AppConfig,
   page: mucr_options
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen getJourney(JourneyType.ASSOCIATE_UCR)) { implicit request =>
     val mucrOptions = request.answersAs[AssociateUcrAnswers].mucrOptions
-    Ok(page(mucrOptions.fold(form)(form.fill)))
+    Ok(page(mucrOptions.fold(form)(form.fill), request.cache.queryUcr))
   }
 
   def save(): Action[AnyContent] = (authenticate andThen getJourney(JourneyType.ASSOCIATE_UCR)).async { implicit request =>
     form
       .bindFromRequest()
       .fold(
-        formWithErrors => Future.successful(BadRequest(page(formWithErrors))),
+        formWithErrors => Future.successful(BadRequest(page(formWithErrors, request.cache.queryUcr))),
         validForm => {
           val validatedForm = MucrOptions.validateForm(form.fill(validForm))
           if (validatedForm.hasErrors) {
-            Future.successful(BadRequest(page(validatedForm)))
+            Future.successful(BadRequest(page(validatedForm, request.cache.queryUcr)))
           } else {
             val updatedAnswers = request.answersAs[AssociateUcrAnswers].copy(mucrOptions = Some(validForm))
             cacheRepository.upsert(request.cache.update(updatedAnswers)).map { _ =>
-              Redirect(routes.AssociateUcrController.displayPage())
+              if (appConfig.ileQueryEnabled)
+                Redirect(routes.AssociateUcrSummaryController.displayPage())
+              else
+                Redirect(routes.AssociateUcrController.displayPage())
             }
           }
         }

--- a/app/forms/AssociateUcr.scala
+++ b/app/forms/AssociateUcr.scala
@@ -54,9 +54,9 @@ object AssociateUcr {
 
   def apply(ucrBlock: UcrBlock): AssociateUcr =
     ucrBlock.ucrType match {
-      case "M" => AssociateUcr(AssociateKind.Mucr, ucrBlock.ucr)
-      case "D" => AssociateUcr(AssociateKind.Ducr, ucrBlock.ucr)
-      case _   => throw new IllegalArgumentException(s"Invalid ucrType: ${ucrBlock.ucrType}")
+      case UcrType.Mucr.codeValue => AssociateUcr(AssociateKind.Mucr, ucrBlock.ucr)
+      case UcrType.Ducr.codeValue => AssociateUcr(AssociateKind.Ducr, ucrBlock.ucr)
+      case _                      => throw new IllegalArgumentException(s"Invalid ucrType: ${ucrBlock.ucrType}")
     }
 
   val formId: String = "AssociateDucr"

--- a/app/forms/ManageMucrChoice.scala
+++ b/app/forms/ManageMucrChoice.scala
@@ -26,8 +26,8 @@ object ManageMucrChoice {
 
   implicit val format = Json.format[ManageMucrChoice]
 
-  val AssociateThisMucr = "thisMucr"
-  val AssociateAnotherMucr = "anotherMucr"
+  val AssociateThisMucr = "associateThisMucr"
+  val AssociateAnotherMucr = "associateAnotherMucr"
 
   val allChoices = Seq(AssociateThisMucr, AssociateAnotherMucr)
 

--- a/app/forms/ManageMucrChoice.scala
+++ b/app/forms/ManageMucrChoice.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+import forms.EnhancedMapping.requiredRadio
+import play.api.data.{Form, Forms, Mapping}
+import play.api.libs.json.Json
+import utils.validators.forms.FieldValidator.isContainedIn
+
+case class ManageMucrChoice(choice: String)
+
+object ManageMucrChoice {
+
+  implicit val format = Json.format[ManageMucrChoice]
+
+  val AssociateThisMucr = "thisMucr"
+  val AssociateAnotherMucr = "anotherMucr"
+
+  val allChoices = Seq(AssociateThisMucr, AssociateAnotherMucr)
+
+  val mapping: Mapping[ManageMucrChoice] =
+    Forms.mapping(
+      "choice" -> requiredRadio("manageMucr.input.error.empty")
+        .verifying("manageMucr.input.error.incorrectValue", isContainedIn(allChoices))
+    )(ManageMucrChoice.apply)(ManageMucrChoice.unapply)
+
+  def form(): Form[ManageMucrChoice] = Form(mapping)
+}

--- a/app/forms/MucrOptions.scala
+++ b/app/forms/MucrOptions.scala
@@ -40,8 +40,8 @@ object MucrOptions {
 
   def apply(ucrBlock: UcrBlock): MucrOptions =
     ucrBlock.ucrType match {
-      case "M" => MucrOptions("", ucrBlock.ucr, MucrOptions.Add)
-      case _   => throw new IllegalArgumentException(s"Invalid ucrType: ${ucrBlock.ucrType}")
+      case UcrType.Mucr.codeValue => MucrOptions("", ucrBlock.ucr, MucrOptions.Add)
+      case _                      => throw new IllegalArgumentException(s"Invalid ucrType: ${ucrBlock.ucrType}")
     }
 
   def form2Model: (String, String, String) => MucrOptions = {

--- a/app/forms/MucrOptions.scala
+++ b/app/forms/MucrOptions.scala
@@ -16,6 +16,7 @@
 
 package forms
 
+import models.UcrBlock
 import play.api.data.Forms._
 import play.api.data.{Form, Forms}
 import play.api.libs.json.Json
@@ -36,6 +37,12 @@ object MucrOptions {
 
   val Create = "create"
   val Add = "add"
+
+  def apply(ucrBlock: UcrBlock): MucrOptions =
+    ucrBlock.ucrType match {
+      case "M" => MucrOptions("", ucrBlock.ucr, MucrOptions.Add)
+      case _   => throw new IllegalArgumentException(s"Invalid ucrType: ${ucrBlock.ucrType}")
+    }
 
   def form2Model: (String, String, String) => MucrOptions = {
     case (createOrAdd, newMucr, existingMucr) =>

--- a/app/models/cache/Answers.scala
+++ b/app/models/cache/Answers.scala
@@ -58,7 +58,11 @@ trait MovementAnswers extends Answers {
   val location: Option[Location]
 }
 
-case class AssociateUcrAnswers(mucrOptions: Option[MucrOptions] = None, associateUcr: Option[AssociateUcr] = None) extends Answers {
+case class AssociateUcrAnswers(
+  manageMucrChoice: Option[ManageMucrChoice] = None,
+  mucrOptions: Option[MucrOptions] = None,
+  associateUcr: Option[AssociateUcr] = None
+) extends Answers {
   override val `type`: JourneyType.Value = JourneyType.ASSOCIATE_UCR
 }
 
@@ -66,7 +70,7 @@ object AssociateUcrAnswers {
   implicit val format: Format[AssociateUcrAnswers] = Json.format[AssociateUcrAnswers]
 
   def fromUcr(ucrBlock: Option[UcrBlock]): AssociateUcrAnswers =
-    new AssociateUcrAnswers(None, ucrBlock.map(AssociateUcr.apply))
+    new AssociateUcrAnswers(None, None, ucrBlock.map(AssociateUcr.apply))
 }
 
 case class DisassociateUcrAnswers(ucr: Option[DisassociateUcr] = None) extends Answers {

--- a/app/models/cache/Answers.scala
+++ b/app/models/cache/Answers.scala
@@ -64,6 +64,8 @@ case class AssociateUcrAnswers(
   associateUcr: Option[AssociateUcr] = None
 ) extends Answers {
   override val `type`: JourneyType.Value = JourneyType.ASSOCIATE_UCR
+
+  def isAssociateAnotherMucr: Boolean = manageMucrChoice.exists(_.choice == ManageMucrChoice.AssociateAnotherMucr)
 }
 
 object AssociateUcrAnswers {

--- a/app/views/associateucr/associate_ucr.scala.html
+++ b/app/views/associateucr/associate_ucr.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.Title
 @import views.components.BackButton
+@import views.components.config.AssociateUcrPageConfig
 
 @this(  govukLayout: gds_main_template,
         govukButton: GovukButton,
@@ -27,13 +28,14 @@
         exportsInputText: exportsInputText,
         errorSummary: errorSummary,
         sectionHeader: sectionHeader,
+        pageConfig: AssociateUcrPageConfig,
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF)
 
 @(form: Form[AssociateUcr], mucrOptions: MucrOptions)(implicit request: Request[_], messages: Messages)
 
 @govukLayout(
     title = Title("associate.ucr.title", Some("mucrOptions.heading")),
-    backButton = Some(BackButton(messages("site.back"), consolidations.routes.MucrOptionsController.displayPage))) {
+    backButton = Some(BackButton(messages("site.back"), pageConfig.backUrl))) {
 
     @formHelper(action = consolidations.routes.AssociateUcrController.submit(), 'autoComplete -> "off") {
         @errorSummary(form.errors)

--- a/app/views/associateucr/associate_ucr_summary_no_change.scala.html
+++ b/app/views/associateucr/associate_ucr_summary_no_change.scala.html
@@ -1,0 +1,95 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import forms.AssociateUcr
+@import views.Title
+@import components.gds.{gds_main_template, pageTitle}
+@import forms.ShutMucr
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.Title
+@import views.components.BackButton
+@import forms.AssociateKind
+@import forms.ManageMucrChoice
+
+@this(  govukLayout: gds_main_template,
+govukButton: GovukButton,
+pageTitle: pageTitle,
+govukSummaryList : GovukSummaryList,
+formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF)
+
+@(consignmentRef: String, associateWith: String, associateKind: AssociateKind, manageMucrChoice: Option[ManageMucrChoice])(implicit request: Request[_], messages: Messages)
+
+@backCall = @{
+    manageMucrChoice.map(_.choice) match {
+        case Some(choice) if choice == ManageMucrChoice.AssociateAnotherMucr => consolidations.routes.AssociateUcrController.displayPage
+        case _ => consolidations.routes.MucrOptionsController.displayPage
+    }
+}
+
+@changeUrl = @{
+    manageMucrChoice.map(_.choice) match {
+        case Some(choice) if choice == ManageMucrChoice.AssociateAnotherMucr => consolidations.routes.AssociateUcrController.displayPage.url
+        case _ => consolidations.routes.MucrOptionsController.displayPage.url
+    }
+}
+
+@govukLayout(
+    title = Title("associate.ucr.summary.title"),
+    backButton = Some(BackButton(messages("site.back"), backCall))) {
+
+    @formHelper(action = consolidations.routes.AssociateUcrSummaryController.submit(), 'autoComplete -> "off") {
+
+        @pageTitle(messages("associate.ucr.summary.title"))
+
+        @govukSummaryList(SummaryList(
+            rows = Seq(
+                SummaryListRow(
+                    key = Key(
+                        content = Text(messages("associate.ucr.summary.consignmentReference"))
+                    ),
+                    value = Value(
+                        content = Text(consignmentRef)
+                    ),
+                    actions = None
+                ),
+                SummaryListRow(
+                    key = Key(
+                        content = Text(messages(s"associate.ucr.summary.associate.with.${associateKind.formValue}"))
+                    ),
+                    value = Value(
+                        content = Text(associateWith)
+                    ),
+                    actions = Some(Actions(
+                        items = Seq(
+                            ActionItem(
+                                href = changeUrl,
+                                content = Text(messages("site.change")),
+                                visuallyHiddenText = Some(messages(s"site.change.hint.associate.${associateKind.formValue}"))
+                            )
+                        )
+                    ))
+                )
+            ),
+            classes = "govuk-!-margin-bottom-9"
+        ))
+
+
+        @govukButton(Button(content = Text(messages("site.confirmAndSubmit"))))
+
+    }
+
+}
+

--- a/app/views/associateucr/manage_mucr.scala.html
+++ b/app/views/associateucr/manage_mucr.scala.html
@@ -1,0 +1,73 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import forms.MucrOptions
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.Title
+@import views.components.BackButton
+@import components.gds.{errorSummary, sectionHeader, gds_main_template}
+@import components.gds.exportsInputText
+@import forms.ManageMucrChoice
+
+@this(
+govukLayout: gds_main_template,
+govukButton: GovukButton,
+govukRadios: GovukRadios,
+govukInput: GovukInput,
+errorSummary: errorSummary,
+exportsInputText: exportsInputText,
+sectionHeader: sectionHeader,
+formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
+
+@(form: Form[ManageMucrChoice], queryUcr: Option[UcrBlock])(implicit request: Request[_], messages: Messages)
+
+@govukLayout(
+    title = Title("manageMucr.title"),
+    backButton = Some(BackButton(messages("site.back"), controllers.routes.ChoiceController.displayChoiceForm))) {
+
+    @formHelper(action = consolidations.routes.ManageMucrController.submit(), 'autoComplete -> "off") {
+        @errorSummary(form.errors)
+
+        @sectionHeader(messages("manageMucr.heading", queryUcr.map(_.ucr).getOrElse("")))
+
+        @govukRadios(Radios(
+            name = "choice",
+            fieldset = Some(Fieldset(
+                legend = Some(Legend(
+                    content = Text(messages("manageMucr.title")),
+                    isPageHeading = true,
+                    classes = "govuk-fieldset__legend--l"
+                ))
+            )),
+            items = Seq(
+                RadioItem(
+                    value = Some(ManageMucrChoice.AssociateThisMucr),
+                    content = Text(messages("manageMucr.associate.this.consignment")),
+                    checked = form("choice").value.contains(ManageMucrChoice.AssociateThisMucr)
+                ),
+                RadioItem(
+                    value = Some(ManageMucrChoice.AssociateAnotherMucr),
+                    content = Text(messages("manageMucr.associate.other.consignment")),
+                    checked = form("choice").value.contains(ManageMucrChoice.AssociateAnotherMucr)
+                )
+            ),
+            errorMessage = form("choice").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+        ))
+
+        @govukButton(Button(content = Text(messages("site.continue"))))
+    }
+}

--- a/app/views/associateucr/mucr_options.scala.html
+++ b/app/views/associateucr/mucr_options.scala.html
@@ -14,6 +14,7 @@
  * limitations under the License.
  *@
 
+@import forms.ManageMucrChoice
 @import forms.MucrOptions
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.Title
@@ -36,11 +37,11 @@
   formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
-@(form: Form[MucrOptions], queryUcr: Option[UcrBlock])(implicit request: JourneyRequest[_], messages: Messages)
+@(form: Form[MucrOptions], queryUcr: Option[UcrBlock], manageMucrChoice: Option[ManageMucrChoice])(implicit request: JourneyRequest[_], messages: Messages)
 
 @govukLayout(
     title = Title("mucrOptions.title"),
-    backButton = Some(BackButton(messages("site.back"), pageConfig.backUrl()))) {
+    backButton = Some(BackButton(messages("site.back"), pageConfig.backUrl(manageMucrChoice)))) {
 
     @formHelper(action = consolidations.routes.MucrOptionsController.save(), 'autoComplete -> "off") {
         @errorSummary(form.errors)

--- a/app/views/associateucr/mucr_options.scala.html
+++ b/app/views/associateucr/mucr_options.scala.html
@@ -20,6 +20,8 @@
 @import views.components.BackButton
 @import components.gds.{errorSummary, sectionHeader, gds_main_template}
 @import components.gds.exportsInputText
+@import views.components.config.MucrOptionsConfig
+@import models.requests.JourneyRequest
 
 
 @this(
@@ -30,19 +32,20 @@
   errorSummary: errorSummary,
   exportsInputText: exportsInputText,
   sectionHeader: sectionHeader,
+  pageConfig: MucrOptionsConfig,
   formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
-@(form: Form[MucrOptions])(implicit request: Request[_], messages: Messages)
+@(form: Form[MucrOptions], queryUcr: Option[UcrBlock])(implicit request: JourneyRequest[_], messages: Messages)
 
 @govukLayout(
     title = Title("mucrOptions.title"),
-    backButton = Some(BackButton(messages("site.back.toStartPage"), controllers.routes.ChoiceController.displayChoiceForm))) {
+    backButton = Some(BackButton(messages("site.back"), pageConfig.backUrl()))) {
 
     @formHelper(action = consolidations.routes.MucrOptionsController.save(), 'autoComplete -> "off") {
         @errorSummary(form.errors)
 
-        @sectionHeader(messages("mucrOptions.heading"))
+        @sectionHeader(messages("mucrOptions.heading", queryUcr.map(_.ucr).getOrElse("")))
 
         @govukRadios(Radios(
             name = "createOrAdd",

--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -64,7 +64,7 @@
         )
     )
 
-    if (pageConfig.isQueryEnabled) commonChoices
+    if (pageConfig.ileQueryEnabled) commonChoices
     else commonChoices :+ RadioItem(
         value = Some(Submissions.value.toString),
         content = Text(messages(s"movement.choice.${Submissions.toString.toLowerCase}.label")),
@@ -79,7 +79,7 @@
     @formHelper(action = routes.ChoiceController.submitChoice(), 'autoComplete -> "off") {
         @errorSummary(form.errors)
 
-        @if(pageConfig.isQueryEnabled) {
+        @if(pageConfig.ileQueryEnabled) {
             @sectionHeader(messages("movement.choice.section", queryUcr.map(_.ucr).getOrElse("")))
         }
 

--- a/app/views/components/config/AssociateUcrPageConfig.scala
+++ b/app/views/components/config/AssociateUcrPageConfig.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components.config
+
+import config.AppConfig
+import javax.inject.Inject
+import play.api.mvc.Call
+
+class AssociateUcrPageConfig @Inject()(appConfig: AppConfig) {
+
+  def backUrl: Call =
+    if (appConfig.ileQueryEnabled)
+      controllers.consolidations.routes.ManageMucrController.displayPage()
+    else
+      controllers.consolidations.routes.MucrOptionsController.displayPage()
+}

--- a/app/views/components/config/MucrOptionsConfig.scala
+++ b/app/views/components/config/MucrOptionsConfig.scala
@@ -17,16 +17,15 @@
 package views.components.config
 
 import config.AppConfig
+import forms.ManageMucrChoice
 import javax.inject.Inject
-import models.cache.AssociateUcrAnswers
-import models.requests.JourneyRequest
 import play.api.mvc.Call
 
 class MucrOptionsConfig @Inject()(appConfig: AppConfig) extends BaseConfig(appConfig) {
 
-  def backUrl()(implicit request: JourneyRequest[_]): Call =
+  def backUrl(manageMucrChoice: Option[ManageMucrChoice] = None): Call =
     if (appConfig.ileQueryEnabled)
-      if (request.answersAs[AssociateUcrAnswers].manageMucrChoice.isDefined)
+      if (manageMucrChoice.isDefined)
         controllers.consolidations.routes.ManageMucrController.displayPage()
       else
         controllers.routes.ChoiceController.displayChoiceForm()

--- a/app/views/components/config/MucrOptionsConfig.scala
+++ b/app/views/components/config/MucrOptionsConfig.scala
@@ -24,11 +24,8 @@ import play.api.mvc.Call
 class MucrOptionsConfig @Inject()(appConfig: AppConfig) extends BaseConfig(appConfig) {
 
   def backUrl(manageMucrChoice: Option[ManageMucrChoice] = None): Call =
-    if (appConfig.ileQueryEnabled)
-      if (manageMucrChoice.isDefined)
-        controllers.consolidations.routes.ManageMucrController.displayPage()
-      else
-        controllers.routes.ChoiceController.displayChoiceForm()
+    if (appConfig.ileQueryEnabled && manageMucrChoice.isDefined)
+      controllers.consolidations.routes.ManageMucrController.displayPage()
     else
       controllers.routes.ChoiceController.displayChoiceForm()
 }

--- a/app/views/components/config/MucrOptionsConfig.scala
+++ b/app/views/components/config/MucrOptionsConfig.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components.config
+
+import config.AppConfig
+import javax.inject.Inject
+import models.cache.AssociateUcrAnswers
+import models.requests.JourneyRequest
+import play.api.mvc.Call
+
+class MucrOptionsConfig @Inject()(appConfig: AppConfig) extends BaseConfig(appConfig) {
+
+  def backUrl()(implicit request: JourneyRequest[_]): Call =
+    if (appConfig.ileQueryEnabled)
+      if (request.answersAs[AssociateUcrAnswers].manageMucrChoice.isDefined)
+        controllers.consolidations.routes.ManageMucrController.displayPage()
+      else
+        controllers.routes.ChoiceController.displayChoiceForm()
+    else
+      controllers.routes.ChoiceController.displayChoiceForm()
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -27,6 +27,10 @@ POST        /choice                                controllers.ChoiceController.
 GET         /mucr-options                          controllers.consolidations.MucrOptionsController.displayPage()
 POST        /mucr-options                          controllers.consolidations.MucrOptionsController.save()
 
+#Manage MUCR
+GET         /manage-mucr                          controllers.consolidations.ManageMucrController.displayPage()
+POST        /manage-mucr                          controllers.consolidations.ManageMucrController.submit()
+
 #Associate UCR
 GET         /associate-ucr                        controllers.consolidations.AssociateUcrController.displayPage()
 POST        /associate-ucr                        controllers.consolidations.AssociateUcrController.submit()

--- a/conf/messages
+++ b/conf/messages
@@ -61,7 +61,8 @@ site.remove = Remove
 site.change = Change
 site.change.hint.disassociate.ucr = Change {0} dissociation
 site.change.hint.associate.ucr = Change {0} to be added
-site.change.hint.associate.mucr = Change MUCR to be associated to
+site.change.hint.associate.mucr = Change MUCR
+site.change.hint.associate.ducr = Change DUCR
 site.change.hint.shut.mucr = Change MUCR
 site.add.item= Add item
 
@@ -264,7 +265,7 @@ shutMucr.summary.header = Shut master consignment
 shutMucr.summary.type = MUCR
 
 associate.heading = Add to MUCR {0}
-mucrOptions.heading = Add to MUCR
+mucrOptions.heading = Associate consignment {0}
 mucrOptions.title = Create or enter a Master Consignment Reference (MUCR) to associate with
 mucrOptions.create = Create a new Master Consignment Reference (MUCR)
 mucrOptions.add = Add to an existing Master Consignment Reference (MUCR)
@@ -273,6 +274,13 @@ mucrOptions.add.reference = Which MUCR do you want to add to?
 mucrOptions.createAdd.value.empty = Please select an option
 mucrOptions.reference.value.empty = Please enter a reference
 mucrOptions.reference.value.error = Please enter a valid reference
+
+manageMucr.title = What do you want to associate?
+manageMucr.heading = Associate consignment {0}
+manageMucr.input.error.empty = Please, choose what do you want to do
+manageMucr.input.error.incorrectValue = Please, choose valid option
+manageMucr.associate.this.consignment = Associate this consignment to another
+manageMucr.associate.other.consignment = Associate another consignment to this one
 
 ducr.error.empty = Please provide Declaration Unique Consignment Reference
 ducr.error.format = Declaration Unique Consignment Reference is in incorrect format
@@ -288,6 +296,9 @@ associate.ucr.mucr.label = Master Unique Consignment Reference
 associate.ucr.hint = You may want to keep a record of which consignments you have added to this MUCR.
 
 associate.ucr.summary.title = Is the information provided for this association request correct?
+associate.ucr.summary.consignmentReference = Consignment reference
+associate.ucr.summary.associate.with.mucr = Associate with MUCR
+associate.ucr.summary.associate.with.ducr = Associate with DUCR
 associate.ucr.summary.kind.mucr = MUCR
 associate.ucr.summary.kind.ducr = DUCR
 associate.ucr.summary.addConsignment = Add consignment

--- a/test/it/AssociateUcrSpecWithIleQueryDisable.scala
+++ b/test/it/AssociateUcrSpecWithIleQueryDisable.scala
@@ -15,59 +15,15 @@
  */
 
 import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, equalToJson, matchingJsonPath, verify}
-import forms._
-import models.UcrBlock
-import models.cache.{AssociateUcrAnswers, Cache}
+import forms.{AssociateKind, AssociateUcr, MucrOptions}
+import models.cache.AssociateUcrAnswers
+import play.api.Configuration
 import play.api.test.Helpers._
 
-class AssociateUcrSpec extends IntegrationSpec {
+class AssociateUcrSpecWithIleQueryDisable extends IntegrationSpec {
 
-  "Manage Mucr Page" when {
-    "GET" should {
-      "return 200 when queried mucr" in {
-        givenAuthSuccess("eori")
-        givenCacheFor(Cache("eori", Some(AssociateUcrAnswers()), Some(UcrBlock("mucr", UcrType.Mucr))))
-
-        val response = get(controllers.consolidations.routes.ManageMucrController.displayPage())
-
-        status(response) mustBe OK
-      }
-
-      "return 303 when queried ducr" in {
-        givenAuthSuccess("eori")
-        givenCacheFor(Cache("eori", Some(AssociateUcrAnswers()), Some(UcrBlock("ducr", UcrType.Ducr))))
-
-        val response = get(controllers.consolidations.routes.ManageMucrController.displayPage())
-
-        status(response) mustBe SEE_OTHER
-        redirectLocation(response) mustBe Some(controllers.consolidations.routes.MucrOptionsController.displayPage().url)
-      }
-    }
-
-    "POST" should {
-      "continue for associate this mucr" in {
-        givenAuthSuccess("eori")
-        givenCacheFor("eori", AssociateUcrAnswers())
-
-        val response = post(controllers.consolidations.routes.ManageMucrController.submit(), "choice" -> ManageMucrChoice.AssociateThisMucr)
-
-        status(response) mustBe SEE_OTHER
-        redirectLocation(response) mustBe Some(controllers.consolidations.routes.MucrOptionsController.displayPage().url)
-        theAnswersFor("eori") mustBe Some(AssociateUcrAnswers(manageMucrChoice = Some(ManageMucrChoice(ManageMucrChoice.AssociateThisMucr))))
-      }
-
-      "continue for associate another mucr" in {
-        givenAuthSuccess("eori")
-        givenCacheFor("eori", AssociateUcrAnswers())
-
-        val response = post(controllers.consolidations.routes.ManageMucrController.submit(), "choice" -> ManageMucrChoice.AssociateAnotherMucr)
-
-        status(response) mustBe SEE_OTHER
-        redirectLocation(response) mustBe Some(controllers.consolidations.routes.AssociateUcrController.displayPage().url)
-        theAnswersFor("eori") mustBe Some(AssociateUcrAnswers(manageMucrChoice = Some(ManageMucrChoice(ManageMucrChoice.AssociateAnotherMucr))))
-      }
-    }
-  }
+  override def ileQueryFeatureConfiguration: Configuration =
+    Configuration.from(Map("microservice.services.features.ileQuery" -> "disabled"))
 
   "UCR Options Page" when {
     "GET" should {
@@ -94,7 +50,7 @@ class AssociateUcrSpec extends IntegrationSpec {
         )
 
         status(response) mustBe SEE_OTHER
-        redirectLocation(response) mustBe Some(controllers.consolidations.routes.AssociateUcrSummaryController.displayPage().url)
+        redirectLocation(response) mustBe Some(controllers.consolidations.routes.AssociateUcrController.displayPage().url)
         theAnswersFor("eori") mustBe Some(AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345"))))
       }
     }

--- a/test/unit/controllers/ChoiceControllerSpec.scala
+++ b/test/unit/controllers/ChoiceControllerSpec.scala
@@ -159,7 +159,7 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
 
           status(result) mustBe SEE_OTHER
           redirectLocation(result) mustBe Some(consolidationRoutes.MucrOptionsController.displayPage().url)
-          theCacheUpserted.answers mustBe Some(AssociateUcrAnswers(None, Some(AssociateUcr(AssociateKind.Mucr, ucrBlock.ucr))))
+          theCacheUpserted.answers mustBe Some(AssociateUcrAnswers(None, None, Some(AssociateUcr(AssociateKind.Mucr, ucrBlock.ucr))))
         }
       }
 

--- a/test/unit/controllers/ControllerLayerSpec.scala
+++ b/test/unit/controllers/ControllerLayerSpec.scala
@@ -20,7 +20,7 @@ import base.UnitSpec
 import config.AppConfig
 import controllers.actions._
 import controllers.exception.InvalidFeatureStateException
-import models.SignedInUser
+import models.{SignedInUser, UcrBlock}
 import models.cache.JourneyType.JourneyType
 import models.cache.{Answers, Cache}
 import models.requests.{AuthenticatedRequest, JourneyRequest}
@@ -62,12 +62,12 @@ abstract class ControllerLayerSpec extends UnitSpec with BeforeAndAfterEach with
       Future.successful(Results.Forbidden)
   }
 
-  case class ValidJourney(answers: Answers) extends JourneyRefiner(mock[CacheRepository]) {
+  case class ValidJourney(answers: Answers, queryUcr: Option[UcrBlock] = None) extends JourneyRefiner(mock[CacheRepository]) {
     override protected def refine[A](request: AuthenticatedRequest[A]): Future[Either[Result, JourneyRequest[A]]] =
-      Future.successful(Right(JourneyRequest(Cache(request.eori, Some(answers), None), request)))
+      Future.successful(Right(JourneyRequest(Cache(request.eori, Some(answers), queryUcr), request)))
 
     override def apply(types: JourneyType*): ActionRefiner[AuthenticatedRequest, JourneyRequest] =
-      if (types.contains(answers.`type`)) ValidJourney(answers) else InValidJourney
+      if (types.contains(answers.`type`)) ValidJourney(answers, queryUcr) else InValidJourney
   }
 
   case object InValidJourney extends JourneyRefiner(mock[CacheRepository]) {

--- a/test/unit/controllers/consolidations/AssociateUcrControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUcrControllerSpec.scala
@@ -66,7 +66,7 @@ class AssociateUcrControllerSpec extends ControllerLayerSpec with MockCache {
       "display page method is invoked and Mucr Options page has data" in {
         val request = getRequest()
 
-        val result = controller(AssociateUcrAnswers(Some(mucrOptions))).displayPage()(request)
+        val result = controller(AssociateUcrAnswers(None, Some(mucrOptions))).displayPage()(request)
 
         status(result) must be(OK)
         theFormRendered.value mustBe empty
@@ -75,7 +75,7 @@ class AssociateUcrControllerSpec extends ControllerLayerSpec with MockCache {
       "display previously gathered data" in {
         val request = getRequest()
 
-        val result = controller(AssociateUcrAnswers(Some(mucrOptions), Some(associateUcr))).displayPage()(request)
+        val result = controller(AssociateUcrAnswers(None, Some(mucrOptions), Some(associateUcr))).displayPage()(request)
 
         status(result) must be(OK)
         theFormRendered.value.get mustBe AssociateUcr(Ducr, "DUCR")
@@ -101,7 +101,7 @@ class AssociateUcrControllerSpec extends ControllerLayerSpec with MockCache {
 
     "return 400 (BAD_REQUEST)" when {
       "form is incorrect and cache contains data from previous page" in {
-        val result = controller(AssociateUcrAnswers(Some(mucrOptions))).submit()(postRequest(Json.obj()))
+        val result = controller(AssociateUcrAnswers(None, Some(mucrOptions))).submit()(postRequest(Json.obj()))
 
         status(result) must be(BAD_REQUEST)
       }
@@ -111,7 +111,7 @@ class AssociateUcrControllerSpec extends ControllerLayerSpec with MockCache {
       "form is correct" in {
         val validDUCR = AssociateUcr.mapping.unbind(AssociateUcr(Ducr, validDucr))
 
-        val result = controller(AssociateUcrAnswers(Some(mucrOptions))).submit()(postRequest(validDUCR))
+        val result = controller(AssociateUcrAnswers(None, Some(mucrOptions))).submit()(postRequest(validDUCR))
         status(result) must be(SEE_OTHER)
         redirectLocation(result) mustBe Some(routes.AssociateUcrSummaryController.displayPage().url)
       }

--- a/test/unit/controllers/consolidations/AssociateUcrSummaryControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUcrSummaryControllerSpec.scala
@@ -16,6 +16,7 @@
 
 package controllers.consolidations
 
+import config.AppConfig
 import controllers.ControllerLayerSpec
 import controllers.storage.FlashKeys
 import forms.AssociateKind._
@@ -30,7 +31,7 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.SubmissionService
-import views.html.associateucr.associate_ucr_summary
+import views.html.associateucr.{associate_ucr_summary, associate_ucr_summary_no_change}
 
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.Future
@@ -39,6 +40,9 @@ class AssociateUcrSummaryControllerSpec extends ControllerLayerSpec with ScalaFu
 
   private val submissionService = mock[SubmissionService]
   private val mockAssociateDucrSummaryPage = mock[associate_ucr_summary]
+  private val mockAssociateDucrSummaryNoChangePage = mock[associate_ucr_summary_no_change]
+
+  private val appConfig = mock[AppConfig]
 
   private def controller(answers: AssociateUcrAnswers) =
     new AssociateUcrSummaryController(
@@ -46,7 +50,9 @@ class AssociateUcrSummaryControllerSpec extends ControllerLayerSpec with ScalaFu
       ValidJourney(answers),
       stubMessagesControllerComponents(),
       submissionService,
-      mockAssociateDucrSummaryPage
+      appConfig,
+      mockAssociateDucrSummaryPage,
+      mockAssociateDucrSummaryNoChangePage
     )(global)
 
   override protected def beforeEach(): Unit = {
@@ -77,7 +83,7 @@ class AssociateUcrSummaryControllerSpec extends ControllerLayerSpec with ScalaFu
     "return 200 (OK)" when {
 
       "display page is invoked with data in cache" in {
-        val result = controller(AssociateUcrAnswers(Some(mucrOptions), Some(associateUcr))).displayPage()(getRequest())
+        val result = controller(AssociateUcrAnswers(None, Some(mucrOptions), Some(associateUcr))).displayPage()(getRequest())
 
         status(result) mustBe OK
         verify(mockAssociateDucrSummaryPage).apply(any(), any())(any(), any())

--- a/test/unit/controllers/consolidations/ManageMucrControllerSpec.scala
+++ b/test/unit/controllers/consolidations/ManageMucrControllerSpec.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.consolidations
+
+import controllers.ControllerLayerSpec
+import controllers.actions.IleQueryAction
+import controllers.exception.InvalidFeatureStateException
+import forms.{ManageMucrChoice, UcrType}
+import models.UcrBlock
+import models.cache.AssociateUcrAnswers
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, verify, when}
+import org.scalatest.OptionValues
+import play.api.data.Form
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import play.twirl.api.HtmlFormat
+import repository.MockCache
+import views.html.associateucr.manage_mucr
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ManageMucrControllerSpec extends ControllerLayerSpec with MockCache with OptionValues {
+
+  private val page = mock[manage_mucr]
+
+  private def controller(
+    answers: AssociateUcrAnswers,
+    ileQueryAction: IleQueryAction = IleQueryEnabled,
+    queryUcr: Option[UcrBlock] = Some(UcrBlock("mucr", UcrType.Mucr))
+  ) =
+    new ManageMucrController(SuccessfulAuth(), ileQueryAction, ValidJourney(answers, queryUcr), stubMessagesControllerComponents(), cache, page)
+
+  override def beforeEach() {
+    super.beforeEach()
+    when(page.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  override def afterEach(): Unit = {
+    reset(page)
+    super.afterEach()
+  }
+
+  private def theFormRendered: Form[ManageMucrChoice] = {
+    val captor: ArgumentCaptor[Form[ManageMucrChoice]] = ArgumentCaptor.forClass(classOf[Form[ManageMucrChoice]])
+    verify(page).apply(captor.capture(), any())(any(), any())
+    captor.getValue
+  }
+
+  "Manage Mucr Controller" should {
+
+    "return 200 (OK)" when {
+
+      "display page method is invoked" in {
+        val result = controller(AssociateUcrAnswers()).displayPage()(getRequest())
+
+        status(result) mustBe OK
+        theFormRendered.value mustBe empty
+      }
+
+      "display page with filled data" in {
+        val manageMucrChoice = ManageMucrChoice(ManageMucrChoice.AssociateAnotherMucr)
+
+        val result = controller(AssociateUcrAnswers(Some(manageMucrChoice), None, None)).displayPage()(getRequest())
+
+        status(result) mustBe OK
+        theFormRendered.value.get.choice mustBe ManageMucrChoice.AssociateAnotherMucr
+      }
+    }
+
+    "return 400 (BAD_REQUEST)" when {
+
+      "form is incorrect during saving" in {
+        val incorrectForm = Json.toJson(ManageMucrChoice("invalid"))
+
+        val result = controller(AssociateUcrAnswers()).submit()(postRequest(incorrectForm))
+
+        status(result) mustBe BAD_REQUEST
+        verify(page).apply(any(), any())(any(), any())
+      }
+    }
+
+    "return 303 (SEE_OTHER)" when {
+
+      "queried ucr was Ducr" in {
+        val result = controller(AssociateUcrAnswers(), queryUcr = Some(UcrBlock("ducr", UcrType.Ducr))).displayPage()(getRequest())
+
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).value mustBe routes.MucrOptionsController.displayPage().url
+      }
+
+      "form is correct with AssociateAnotherMucr option" in {
+        val correctForm = Json.toJson(ManageMucrChoice(ManageMucrChoice.AssociateAnotherMucr))
+
+        val result = controller(AssociateUcrAnswers()).submit()(postRequest(correctForm))
+
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).value mustBe routes.AssociateUcrController.displayPage().url
+      }
+
+      "form is correct with AssociateThisMucr option" in {
+        val correctForm = Json.toJson(ManageMucrChoice(ManageMucrChoice.AssociateThisMucr))
+
+        val result = controller(AssociateUcrAnswers()).submit()(postRequest(correctForm))
+
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).value mustBe routes.MucrOptionsController.displayPage().url
+      }
+    }
+  }
+
+  "Manage Mucr Controller when accessed in illegal state" should {
+
+    "block access" when {
+
+      "ileQuery feature disabled" in {
+
+        intercept[RuntimeException] {
+          await(controller(AssociateUcrAnswers(), IleQueryDisabled).displayPage()(getRequest()))
+        } mustBe InvalidFeatureStateException
+
+      }
+
+      "queried ucr not available in cache" in {
+
+        intercept[RuntimeException] {
+          await(controller(AssociateUcrAnswers(), IleQueryEnabled, queryUcr = None).displayPage()(getRequest()))
+        } mustBe InvalidFeatureStateException
+
+      }
+
+    }
+  }
+}

--- a/test/unit/controllers/consolidations/MucrOptionsControllerSpec.scala
+++ b/test/unit/controllers/consolidations/MucrOptionsControllerSpec.scala
@@ -16,6 +16,7 @@
 
 package controllers.consolidations
 
+import config.AppConfig
 import controllers.ControllerLayerSpec
 import forms.MucrOptions
 import forms.MucrOptions.Create
@@ -39,12 +40,14 @@ class MucrOptionsControllerSpec extends ControllerLayerSpec with MockCache with 
 
   private val page = mock[mucr_options]
 
+  private val appConfig = mock[AppConfig]
+
   private def controller(answers: AssociateUcrAnswers) =
-    new MucrOptionsController(SuccessfulAuth(), ValidJourney(answers), stubMessagesControllerComponents(), cache, page)(global)
+    new MucrOptionsController(SuccessfulAuth(), ValidJourney(answers), stubMessagesControllerComponents(), cache, appConfig, page)(global)
 
   override def beforeEach() {
     super.beforeEach()
-    when(page.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)
+    when(page.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 
   override def afterEach(): Unit = {
@@ -54,7 +57,7 @@ class MucrOptionsControllerSpec extends ControllerLayerSpec with MockCache with 
 
   private def theFormRendered: Form[MucrOptions] = {
     val captor: ArgumentCaptor[Form[MucrOptions]] = ArgumentCaptor.forClass(classOf[Form[MucrOptions]])
-    verify(page).apply(captor.capture())(any(), any())
+    verify(page).apply(captor.capture(), any())(any(), any())
     captor.getValue
   }
 
@@ -72,7 +75,7 @@ class MucrOptionsControllerSpec extends ControllerLayerSpec with MockCache with 
       "display page with filled data" in {
         val mucrOptions = MucrOptions(CommonTestData.correctUcr)
 
-        val result = controller(AssociateUcrAnswers(Some(mucrOptions))).displayPage()(getRequest())
+        val result = controller(AssociateUcrAnswers(None, Some(mucrOptions), None)).displayPage()(getRequest())
 
         status(result) mustBe OK
         theFormRendered.value.get.mucr mustBe CommonTestData.correctUcr
@@ -87,7 +90,7 @@ class MucrOptionsControllerSpec extends ControllerLayerSpec with MockCache with 
         val result = controller(AssociateUcrAnswers()).save()(postRequest(incorrectForm))
 
         status(result) mustBe BAD_REQUEST
-        verify(page).apply(any())(any(), any())
+        verify(page).apply(any(), any())(any(), any())
       }
 
       "form is incorrect during saving on second validation" in {
@@ -96,7 +99,7 @@ class MucrOptionsControllerSpec extends ControllerLayerSpec with MockCache with 
         val result = controller(AssociateUcrAnswers()).save()(postRequest(incorrectForm))
 
         status(result) mustBe BAD_REQUEST
-        verify(page).apply(any())(any(), any())
+        verify(page).apply(any(), any())(any(), any())
       }
     }
 

--- a/test/unit/controllers/consolidations/MucrOptionsControllerSpec.scala
+++ b/test/unit/controllers/consolidations/MucrOptionsControllerSpec.scala
@@ -47,17 +47,17 @@ class MucrOptionsControllerSpec extends ControllerLayerSpec with MockCache with 
 
   override def beforeEach() {
     super.beforeEach()
-    when(page.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
+    when(page.apply(any(), any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 
   override def afterEach(): Unit = {
-    reset(page)
+    reset(page, appConfig)
     super.afterEach()
   }
 
   private def theFormRendered: Form[MucrOptions] = {
     val captor: ArgumentCaptor[Form[MucrOptions]] = ArgumentCaptor.forClass(classOf[Form[MucrOptions]])
-    verify(page).apply(captor.capture(), any())(any(), any())
+    verify(page).apply(captor.capture(), any(), any())(any(), any())
     captor.getValue
   }
 
@@ -90,7 +90,7 @@ class MucrOptionsControllerSpec extends ControllerLayerSpec with MockCache with 
         val result = controller(AssociateUcrAnswers()).save()(postRequest(incorrectForm))
 
         status(result) mustBe BAD_REQUEST
-        verify(page).apply(any(), any())(any(), any())
+        verify(page).apply(any(), any(), any())(any(), any())
       }
 
       "form is incorrect during saving on second validation" in {
@@ -99,19 +99,32 @@ class MucrOptionsControllerSpec extends ControllerLayerSpec with MockCache with 
         val result = controller(AssociateUcrAnswers()).save()(postRequest(incorrectForm))
 
         status(result) mustBe BAD_REQUEST
-        verify(page).apply(any(), any())(any(), any())
+        verify(page).apply(any(), any(), any())(any(), any())
       }
     }
 
     "return 303 (SEE_OTHER)" when {
 
-      "form is correct" in {
+      "form is correct when ileQuery disabled" in {
+        when(appConfig.ileQueryEnabled).thenReturn(false)
+
         val correctForm = Json.toJson(MucrOptions(validMucr, "", Create))
 
         val result = controller(AssociateUcrAnswers()).save()(postRequest(correctForm))
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result).value mustBe routes.AssociateUcrController.displayPage().url
+      }
+
+      "form is correct when ileQuery enabled" in {
+        when(appConfig.ileQueryEnabled).thenReturn(true)
+
+        val correctForm = Json.toJson(MucrOptions(validMucr, "", Create))
+
+        val result = controller(AssociateUcrAnswers()).save()(postRequest(correctForm))
+
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).value mustBe routes.AssociateUcrSummaryController.displayPage().url
       }
     }
   }

--- a/test/unit/services/SubmissionServiceSpec.scala
+++ b/test/unit/services/SubmissionServiceSpec.scala
@@ -63,7 +63,7 @@ class SubmissionServiceSpec extends UnitSpec with MovementsMetricsStub with Befo
         given(connector.submit(any[Consolidation]())(any())).willReturn(Future.successful((): Unit))
         given(repository.removeByEori(anyString())).willReturn(Future.successful((): Unit))
 
-        val answers = AssociateUcrAnswers(Some(MucrOptions(mucr)), Some(AssociateUcr(AssociateKind.Ducr, ucr)))
+        val answers = AssociateUcrAnswers(None, Some(MucrOptions(mucr)), Some(AssociateUcr(AssociateKind.Ducr, ucr)))
         await(service.submit(validEori, answers))
 
         theAssociationSubmitted mustBe AssociateDUCRRequest(validEori, mucr, ucr)
@@ -75,7 +75,7 @@ class SubmissionServiceSpec extends UnitSpec with MovementsMetricsStub with Befo
         given(connector.submit(any[Consolidation]())(any())).willReturn(Future.successful((): Unit))
         given(repository.removeByEori(anyString())).willReturn(Future.successful((): Unit))
 
-        val answers = AssociateUcrAnswers(Some(MucrOptions(mucr)), Some(AssociateUcr(AssociateKind.Mucr, ucr)))
+        val answers = AssociateUcrAnswers(None, Some(MucrOptions(mucr)), Some(AssociateUcr(AssociateKind.Mucr, ucr)))
         await(service.submit(validEori, answers))
 
         theAssociationSubmitted mustBe AssociateMUCRRequest(validEori, mucr, ucr)
@@ -87,7 +87,7 @@ class SubmissionServiceSpec extends UnitSpec with MovementsMetricsStub with Befo
     "audit when failed" in {
       given(connector.submit(any[Consolidation]())(any())).willReturn(Future.failed(new RuntimeException("Error")))
 
-      val answers = AssociateUcrAnswers(Some(MucrOptions(mucr)), Some(AssociateUcr(AssociateKind.Ducr, ucr)))
+      val answers = AssociateUcrAnswers(None, Some(MucrOptions(mucr)), Some(AssociateUcr(AssociateKind.Ducr, ucr)))
       intercept[RuntimeException] {
         await(service.submit(validEori, answers))
       }

--- a/test/unit/views/ChoiceViewSpec.scala
+++ b/test/unit/views/ChoiceViewSpec.scala
@@ -159,6 +159,7 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Injector with
       view.getElementsByAttributeValue("for", "choice-3").text() must be(messages("movement.choice.disassociateucr.label"))
       view.getElementsByAttributeValue("for", "choice-4").text() must be(messages("movement.choice.shutmucr.label"))
       view.getElementsByAttributeValue("for", "choice-5").text() must be(messages("movement.choice.departure.label"))
+      view.getElementsByAttributeValue("for", "choice-6") must be(empty)
     }
 
     "display 6 radio buttons with labels when ileQuery is disabled" in {
@@ -171,10 +172,7 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Injector with
       view.getElementsByAttributeValue("for", "choice-3").text() must be(messages("movement.choice.disassociateucr.label"))
       view.getElementsByAttributeValue("for", "choice-4").text() must be(messages("movement.choice.shutmucr.label"))
       view.getElementsByAttributeValue("for", "choice-5").text() must be(messages("movement.choice.departure.label"))
-
-      if (!realAppConfig.ileQueryEnabled) {
-        view.getElementsByAttributeValue("for", "choice-6").text() must be(messages("movement.choice.submissions.label"))
-      }
+      view.getElementsByAttributeValue("for", "choice-6").text() must be(messages("movement.choice.submissions.label"))
     }
 
     "display 4 unchecked radio buttons" in {

--- a/test/unit/views/ChoiceViewSpec.scala
+++ b/test/unit/views/ChoiceViewSpec.scala
@@ -55,7 +55,7 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Injector with
       if (enabled) controllers.ileQuery.routes.FindConsignmentController.displayQueryForm()
       else controllers.routes.StartController.displayStartPage
     )
-    when(pageConfig.isQueryEnabled).thenReturn(enabled)
+    when(pageConfig.ileQueryEnabled).thenReturn(enabled)
   }
 
   private val choicePage = new choice_page(govukLayout, govukButton, govukRadios, errorSummary, sectionHeader, formHelper, pageConfig)

--- a/test/unit/views/ChoiceViewSpec.scala
+++ b/test/unit/views/ChoiceViewSpec.scala
@@ -171,7 +171,10 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Injector with
       view.getElementsByAttributeValue("for", "choice-3").text() must be(messages("movement.choice.disassociateucr.label"))
       view.getElementsByAttributeValue("for", "choice-4").text() must be(messages("movement.choice.shutmucr.label"))
       view.getElementsByAttributeValue("for", "choice-5").text() must be(messages("movement.choice.departure.label"))
-      view.getElementsByAttributeValue("for", "choice-6").text() must be(messages("movement.choice.submissions.label"))
+
+      if (!realAppConfig.ileQueryEnabled) {
+        view.getElementsByAttributeValue("for", "choice-6").text() must be(messages("movement.choice.submissions.label"))
+      }
     }
 
     "display 4 unchecked radio buttons" in {

--- a/test/unit/views/associateucr/AssociateUcrSummaryNoChangeViewSpec.scala
+++ b/test/unit/views/associateucr/AssociateUcrSummaryNoChangeViewSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.associateucr
+
+import base.Injector
+import forms.{AssociateKind, ManageMucrChoice}
+import models.cache.AssociateUcrAnswers
+import org.jsoup.nodes.Element
+import play.api.mvc.Call
+import play.twirl.api.Html
+import views.ViewSpec
+import views.html.associateucr.associate_ucr_summary_no_change
+import views.tags.ViewTest
+
+@ViewTest
+class AssociateUcrSummaryNoChangeViewSpec extends ViewSpec with Injector {
+
+  private implicit val request = journeyRequest(AssociateUcrAnswers())
+
+  private val page = instanceOf[associate_ucr_summary_no_change]
+
+  private def createView(
+    consignmentRef: String,
+    associateWith: String,
+    associateKind: AssociateKind,
+    manageMucrChoice: Option[ManageMucrChoice]
+  ): Html =
+    page(consignmentRef, associateWith, associateKind, manageMucrChoice)(request, messages)
+
+  "AssociateUcrSummaryNoChange View" should {
+
+    "render title" in {
+      val view = createView("DUCR", "MUCR", AssociateKind.Mucr, None)
+      view.getTitle must containMessage("associate.ucr.summary.title")
+    }
+
+    "display 'Confirm and submit' button on page" in {
+      val view = createView("DUCR", "MUCR", AssociateKind.Mucr, None)
+      view.getElementsByClass("govuk-button").first() must containMessage("site.confirmAndSubmit")
+    }
+
+    "render back button" when {
+
+      def validateBackButton(backButton: Option[Element], call: Call): Unit = {
+        backButton mustBe defined
+        backButton.foreach(button => {
+          button must haveHref(call)
+          button must containMessage("site.back")
+        })
+      }
+
+      "query Ducr" in {
+        val view = createView("DUCR", "MUCR", AssociateKind.Mucr, None)
+        validateBackButton(view.getBackButton, controllers.consolidations.routes.MucrOptionsController.displayPage())
+      }
+
+      "query Mucr and Associate this consignment to another" in {
+        val view = createView("MUCR", "MUCR", AssociateKind.Mucr, Some(ManageMucrChoice(ManageMucrChoice.AssociateThisMucr)))
+        validateBackButton(view.getBackButton, controllers.consolidations.routes.MucrOptionsController.displayPage())
+      }
+
+      "query Mucr and Associate another consignment to this one" in {
+        val view = createView("MUCR", "MUCR", AssociateKind.Mucr, Some(ManageMucrChoice(ManageMucrChoice.AssociateAnotherMucr)))
+        validateBackButton(view.getBackButton, controllers.consolidations.routes.AssociateUcrController.displayPage())
+      }
+    }
+
+    "render change link" when {
+
+      def validateChangeLink(view: Html, call: Call): Unit = {
+        val changeUcr = view.getElementsByClass("govuk-link").first()
+        changeUcr must containMessage("site.change")
+        changeUcr must haveHref(call)
+      }
+
+      "query Ducr" in {
+        val view = createView("DUCR", "MUCR", AssociateKind.Mucr, None)
+        validateChangeLink(view, controllers.consolidations.routes.MucrOptionsController.displayPage())
+      }
+
+      "query Mucr and Associate this consignment to another" in {
+        val view = createView("MUCR", "MUCR", AssociateKind.Mucr, Some(ManageMucrChoice(ManageMucrChoice.AssociateThisMucr)))
+        validateChangeLink(view, controllers.consolidations.routes.MucrOptionsController.displayPage())
+      }
+
+      "query Mucr and Associate another consignment to this one" in {
+        val view = createView("MUCR", "MUCR", AssociateKind.Mucr, Some(ManageMucrChoice(ManageMucrChoice.AssociateAnotherMucr)))
+        validateChangeLink(view, controllers.consolidations.routes.AssociateUcrController.displayPage())
+      }
+    }
+  }
+}

--- a/test/unit/views/associateucr/ManageMucrViewSpec.scala
+++ b/test/unit/views/associateucr/ManageMucrViewSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.associateucr
+
+import base.Injector
+import forms.ManageMucrChoice
+import models.UcrBlock
+import models.cache.AssociateUcrAnswers
+import org.jsoup.nodes.Document
+import play.api.data.{Form, FormError}
+import views.ViewSpec
+import views.html.associateucr.manage_mucr
+
+class ManageMucrViewSpec extends ViewSpec with Injector {
+
+  private implicit val request = journeyRequest(AssociateUcrAnswers())
+
+  private val page = instanceOf[manage_mucr]
+  private val form: Form[ManageMucrChoice] = ManageMucrChoice.form
+
+  private val queryUcr = Some(UcrBlock("mucr", "m"))
+
+  "MUCR options" should {
+
+    "have the correct title" in {
+      page(form, queryUcr).getTitle must containMessage("manageMucr.title")
+    }
+
+    "have the correct heading" in {
+      page(form, queryUcr).getElementById("section-header") must containMessage("manageMucr.heading", "mucr")
+    }
+
+    "render the correct labels" in {
+      val view = page(form, queryUcr)
+      view.getElementsByAttributeValue("for", "choice").first() must containMessage("manageMucr.associate.this.consignment")
+      view.getElementsByAttributeValue("for", "choice-2").first() must containMessage("manageMucr.associate.other.consignment")
+    }
+
+    "display 'Back' button" in {
+      val backButton = page(form, queryUcr).getBackButton
+
+      backButton mustBe defined
+      backButton.foreach(button => {
+        button must haveHref(controllers.routes.ChoiceController.displayChoiceForm())
+        button must containMessage("site.back")
+      })
+    }
+
+    "render error summary" when {
+      "no errors" in {
+        page(form, queryUcr).getErrorSummary mustBe empty
+      }
+
+      "some errors" in {
+        val view: Document = page(form.withError(FormError("choice", "manageMucr.input.error.empty")), queryUcr)
+
+        view must haveGovUkGlobalErrorSummary
+        view must haveGovUkFieldError("choice", messages("manageMucr.input.error.empty"))
+      }
+    }
+  }
+}

--- a/test/unit/views/associateucr/MucrOptionsViewSpec.scala
+++ b/test/unit/views/associateucr/MucrOptionsViewSpec.scala
@@ -18,6 +18,7 @@ package views.associateucr
 
 import base.Injector
 import forms.MucrOptions
+import models.UcrBlock
 import models.cache.ArrivalAnswers
 import org.jsoup.nodes.Document
 import play.api.data.{Form, FormError}
@@ -31,29 +32,33 @@ class MucrOptionsViewSpec extends ViewSpec with Injector {
   private val form: Form[MucrOptions] = MucrOptions.form
   private val page = instanceOf[mucr_options]
 
+  private val queryUcr = Some(UcrBlock("mucr", "m"))
+
   "MUCR options" should {
 
     "have the correct title" in {
-      page(MucrOptions.form).getTitle must containMessage("mucrOptions.title")
+      page(MucrOptions.form, queryUcr).getTitle must containMessage("mucrOptions.title")
     }
 
     "have the correct heading" in {
-      page(MucrOptions.form).getElementById("section-header") must containMessage("mucrOptions.heading")
+      page(MucrOptions.form, queryUcr).getElementById("section-header") must containMessage("mucrOptions.heading")
     }
 
     "render the correct labels and hints" in {
-      page(MucrOptions.form).getElementsByAttributeValue("for", "existingMucr").first() must containMessage("site.inputText.mucr.label")
-      page(MucrOptions.form).getElementsByAttributeValue("for", "newMucr").first() must containMessage("site.inputText.newMucr.label")
-      page(MucrOptions.form).getElementById("newMucr-hint") must containMessage("site.inputText.newMucr.label.hint")
+      val view = page(MucrOptions.form, queryUcr)
+      view.getElementsByAttributeValue("for", "existingMucr").first() must containMessage("site.inputText.mucr.label")
+      view.getElementsByAttributeValue("for", "newMucr").first() must containMessage("site.inputText.newMucr.label")
+      view.getElementById("newMucr-hint") must containMessage("site.inputText.newMucr.label.hint")
     }
 
     "have no options selected on initial display" in {
-      page(MucrOptions.form).getElementById("createOrAdd") mustBe unchecked
-      page(MucrOptions.form).getElementById("createOrAdd-2") mustBe unchecked
+      val view = page(MucrOptions.form, queryUcr)
+      view.getElementById("createOrAdd") mustBe unchecked
+      view.getElementById("createOrAdd-2") mustBe unchecked
     }
 
     "display 'Back' button that links to start page" in {
-      val backButton = page(MucrOptions.form).getBackButton
+      val backButton = page(MucrOptions.form, queryUcr).getBackButton
 
       backButton mustBe defined
       backButton.foreach(button => {
@@ -63,16 +68,16 @@ class MucrOptionsViewSpec extends ViewSpec with Injector {
     }
 
     "display 'Continue' button on page" in {
-      page(MucrOptions.form).getElementsByClass("govuk-button").first() must containMessage("site.continue")
+      page(MucrOptions.form, queryUcr).getElementsByClass("govuk-button").first() must containMessage("site.continue")
     }
 
     "render error summary" when {
       "no errors" in {
-        page(MucrOptions.form).getErrorSummary mustBe empty
+        page(MucrOptions.form, queryUcr).getErrorSummary mustBe empty
       }
 
       "some errors" in {
-        val view: Document = page(MucrOptions.form.withError(FormError("createOrAdd", "mucrOptions.createAdd.value.empty")))
+        val view: Document = page(MucrOptions.form.withError(FormError("createOrAdd", "mucrOptions.createAdd.value.empty")), queryUcr)
 
         view must haveGovUkGlobalErrorSummary
         view must haveGovUkFieldError("createOrAdd", messages("mucrOptions.createAdd.value.empty"))

--- a/test/unit/views/associateucr/MucrOptionsViewSpec.scala
+++ b/test/unit/views/associateucr/MucrOptionsViewSpec.scala
@@ -16,68 +16,104 @@
 
 package views.associateucr
 
-import base.Injector
-import forms.MucrOptions
+import base.OverridableInjector
+import config.AppConfig
+import forms.{ManageMucrChoice, MucrOptions}
 import models.UcrBlock
-import models.cache.ArrivalAnswers
+import models.cache.AssociateUcrAnswers
 import org.jsoup.nodes.Document
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.{Form, FormError}
+import play.api.inject.bind
 import views.ViewSpec
 import views.html.associateucr.mucr_options
 
-class MucrOptionsViewSpec extends ViewSpec with Injector {
+class MucrOptionsViewSpec extends ViewSpec with MockitoSugar with BeforeAndAfterEach {
 
-  private implicit val request = journeyRequest(ArrivalAnswers())
+  private val appConfig = mock[AppConfig]
+  private val injector = new OverridableInjector(bind[AppConfig].toInstance(appConfig))
+
+  private val page = injector.instanceOf[mucr_options]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    when(appConfig.ileQueryEnabled).thenReturn(true)
+  }
+
+  override def afterEach(): Unit = {
+    reset(appConfig)
+
+    super.afterEach()
+  }
+
+  private implicit val request = journeyRequest(AssociateUcrAnswers(manageMucrChoice = Some(ManageMucrChoice(ManageMucrChoice.AssociateAnotherMucr))))
 
   private val form: Form[MucrOptions] = MucrOptions.form
-  private val page = instanceOf[mucr_options]
 
   private val queryUcr = Some(UcrBlock("mucr", "m"))
+  private val manageMucr = Some(ManageMucrChoice(ManageMucrChoice.AssociateAnotherMucr))
+
+  private def createView(form: Form[MucrOptions] = form) = page(form, queryUcr, manageMucr)
 
   "MUCR options" should {
 
     "have the correct title" in {
-      page(MucrOptions.form, queryUcr).getTitle must containMessage("mucrOptions.title")
+      createView().getTitle must containMessage("mucrOptions.title")
     }
 
     "have the correct heading" in {
-      page(MucrOptions.form, queryUcr).getElementById("section-header") must containMessage("mucrOptions.heading")
+      createView().getElementById("section-header") must containMessage("mucrOptions.heading", "mucr")
     }
 
     "render the correct labels and hints" in {
-      val view = page(MucrOptions.form, queryUcr)
+      val view = createView()
       view.getElementsByAttributeValue("for", "existingMucr").first() must containMessage("site.inputText.mucr.label")
       view.getElementsByAttributeValue("for", "newMucr").first() must containMessage("site.inputText.newMucr.label")
       view.getElementById("newMucr-hint") must containMessage("site.inputText.newMucr.label.hint")
     }
 
     "have no options selected on initial display" in {
-      val view = page(MucrOptions.form, queryUcr)
+      val view = createView()
       view.getElementById("createOrAdd") mustBe unchecked
       view.getElementById("createOrAdd-2") mustBe unchecked
     }
 
-    "display 'Back' button that links to start page" in {
-      val backButton = page(MucrOptions.form, queryUcr).getBackButton
+    "display 'Back' button that links to start page when ileQuery disabled" in {
+      when(appConfig.ileQueryEnabled).thenReturn(false)
+      val backButton = createView().getBackButton
 
       backButton mustBe defined
       backButton.foreach(button => {
         button must haveHref(controllers.routes.ChoiceController.displayChoiceForm())
-        button must containMessage("site.back.toStartPage")
+        button must containMessage("site.back")
+      })
+    }
+
+    "display 'Back' button that links to 'manage mucr page when ileQuery enabled" in {
+      when(appConfig.ileQueryEnabled).thenReturn(true)
+      val backButton = createView().getBackButton
+
+      backButton mustBe defined
+      backButton.foreach(button => {
+        button must haveHref(controllers.consolidations.routes.ManageMucrController.displayPage())
+        button must containMessage("site.back")
       })
     }
 
     "display 'Continue' button on page" in {
-      page(MucrOptions.form, queryUcr).getElementsByClass("govuk-button").first() must containMessage("site.continue")
+      createView().getElementsByClass("govuk-button").first() must containMessage("site.continue")
     }
 
     "render error summary" when {
       "no errors" in {
-        page(MucrOptions.form, queryUcr).getErrorSummary mustBe empty
+        createView().getErrorSummary mustBe empty
       }
 
       "some errors" in {
-        val view: Document = page(MucrOptions.form.withError(FormError("createOrAdd", "mucrOptions.createAdd.value.empty")), queryUcr)
+        val view: Document = createView(form.withError(FormError("createOrAdd", "mucrOptions.createAdd.value.empty")))
 
         view must haveGovUkGlobalErrorSummary
         view must haveGovUkFieldError("createOrAdd", messages("mucrOptions.createAdd.value.empty"))

--- a/test/unit/views/components/config/AssociateUcrPageConfigSpec.scala
+++ b/test/unit/views/components/config/AssociateUcrPageConfigSpec.scala
@@ -16,17 +16,27 @@
 
 package views.components.config
 
-import config.AppConfig
-import javax.inject.Inject
+import base.UnitSpec
 import models.UcrBlock
-import play.api.mvc.Call
 
-class ChoicePageConfig @Inject()(appConfig: AppConfig) extends BaseConfig(appConfig) {
-  def backLink(queryUcr: Option[UcrBlock]): Call =
-    if (appConfig.ileQueryEnabled)
-      queryUcr
-        .map(block => controllers.ileQuery.routes.IleQueryController.getConsignmentInformation(block.ucr))
-        .getOrElse(controllers.ileQuery.routes.FindConsignmentController.displayQueryForm())
-    else
-      controllers.routes.StartController.displayStartPage
+class AssociateUcrPageConfigSpec extends UnitSpec with IleQueryFeatureConfigSpec {
+
+  "AssociateUcrPageConfig when ileQuery disabled" should {
+
+    val config = new AssociateUcrPageConfig(ileQueryDisabled)
+
+    "return correct back url" in {
+      config.backUrl mustBe controllers.consolidations.routes.MucrOptionsController.displayPage()
+    }
+  }
+
+  "AssociateUcrPageConfig when ileQuery enabled" should {
+
+    val config = new AssociateUcrPageConfig(ileQueryEnabled)
+
+    "return correct back url" in {
+
+      config.backUrl mustBe controllers.consolidations.routes.ManageMucrController.displayPage()
+    }
+  }
 }

--- a/test/unit/views/components/config/ChoicePageConfigSpec.scala
+++ b/test/unit/views/components/config/ChoicePageConfigSpec.scala
@@ -34,7 +34,7 @@ class ChoicePageConfigSpec extends UnitSpec with IleQueryFeatureConfigSpec {
 
     "return information about ile query" in {
 
-      config.isQueryEnabled mustBe false
+      config.ileQueryEnabled mustBe false
     }
   }
 
@@ -54,7 +54,7 @@ class ChoicePageConfigSpec extends UnitSpec with IleQueryFeatureConfigSpec {
 
     "return information about ile query" in {
 
-      config.isQueryEnabled mustBe true
+      config.ileQueryEnabled mustBe true
     }
   }
 }

--- a/test/unit/views/components/config/MucrOptionsConfigSpec.scala
+++ b/test/unit/views/components/config/MucrOptionsConfigSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components.config
+
+import base.UnitSpec
+import forms.ManageMucrChoice
+import forms.ManageMucrChoice.AssociateAnotherMucr
+
+class MucrOptionsConfigSpec extends UnitSpec with IleQueryFeatureConfigSpec {
+
+  "MucrOptionsConfig when ileQuery disabled" should {
+
+    val config = new MucrOptionsConfig(ileQueryDisabled)
+
+    "return correct back url" in {
+      config.backUrl() mustBe controllers.routes.ChoiceController.displayChoiceForm()
+    }
+  }
+
+  "MucrOptionsConfig when ileQuery enabled" should {
+
+    val config = new MucrOptionsConfig(ileQueryEnabled)
+
+    "return correct back url" when {
+
+      "associating a queried mucr" in {
+        config.backUrl(Some(ManageMucrChoice(AssociateAnotherMucr))) mustBe controllers.consolidations.routes.ManageMucrController.displayPage()
+      }
+
+      "associating a queried ducr" in {
+        config.backUrl(None) mustBe controllers.routes.ChoiceController.displayChoiceForm()
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR prevents the user changing the queried Ucr when on the Associate journey.
Includes the new ability to associate queried Mucr with another Mucr or vice verse.
Includes new summary page for Associate journey in line with latest prototype.