### PR TITLE
CEDS-2216 - External Movements: Add MRN to Movements Query results page

### DIFF
--- a/app/views/components/ilequery/response_ducr_summary.scala.html
+++ b/app/views/components/ilequery/response_ducr_summary.scala.html
@@ -62,6 +62,14 @@
                 value = Value(
                     content = info.entryStatus.flatMap(_.ics).map(converter.inputCustomsStatus(_)).getOrElse(Empty)
                 )
+            ),
+            SummaryListRow(
+                key = Key(
+                    content = Text(messages("ileQueryResponse.details.MRN"))
+                ),
+                value = Value(
+                    content = HtmlContent(info.declarationId)
+                )
             )
         ).filterNot(_.value.content == Empty),
         classes = "govuk-!-margin-bottom-9"

--- a/conf/messages
+++ b/conf/messages
@@ -391,6 +391,7 @@ ileQueryResponse.details = Queried UCR details
 ileQueryResponse.details.route = Route
 ileQueryResponse.details.entryStatus = Status
 ileQueryResponse.details.inputCustomsStatus = Input status
+ileQueryResponse.details.MRN = MRN
 ileQueryResponse.details.transport = Transport
 ileQueryResponse.details.isShutMucr.true = Shut
 ileQueryResponse.details.isShutMucr.false = Open

--- a/test/unit/views/components/ilequery/DucrSummaryViewSpec.scala
+++ b/test/unit/views/components/ilequery/DucrSummaryViewSpec.scala
@@ -84,12 +84,17 @@ class DucrSummaryViewSpec extends ViewSpec with Injector {
       summaryElement(summaryView, 3) must containMessage("ileCode.unknown")
     }
 
+    "render MRN" in {
+      summaryElement(view(), 4).text() must include(ducrInfo.declarationId)
+    }
+
     "render all rows" in {
       val summaryText = view().text()
       summaryText must include("Route")
       summaryText must include("Status")
       summaryText must include("Transport")
       summaryText must include("Input status")
+      summaryText must include("MRN")
     }
 
     "not render rows when codes and transport missing" in {


### PR DESCRIPTION
A queried DUCR must show the MRN on the results page. In contrast, there must be no MRN displayed on the results page when a MUCR is queried.