### PR TITLE
CEDS-2609 - workaround for an issue with govukSummaryList 

### DIFF
--- a/app/views/associateucr/associate_ucr_summary_no_change.scala.html
+++ b/app/views/associateucr/associate_ucr_summary_no_change.scala.html
@@ -22,12 +22,12 @@
 @import forms.ManageMucrChoice
 
 @this(
-    govukLayout: gds_main_template,
-    govukButton: GovukButton,
-    pageTitle: pageTitle,
-    govukSummaryList : GovukSummaryList,
-    linkContent: linkContent,
-    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+govukLayout: gds_main_template,
+govukButton: GovukButton,
+pageTitle: pageTitle,
+govukSummaryList : GovukSummaryList,
+linkContent: linkContent,
+formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(consignmentRef: String, associateWith: String, associateKind: UcrType, manageMucrChoice: Option[ManageMucrChoice])(implicit request: Request[_], messages: Messages)
@@ -64,7 +64,13 @@
                         content = Text(consignmentRef)
                     ),
                     actions = None
-                ),
+                )
+            ),
+            classes = "govuk-!-margin-bottom-1"
+        ))
+
+        @govukSummaryList(SummaryList(
+            rows = Seq(
                 SummaryListRow(
                     key = Key(
                         content = Text(messages(s"associate.ucr.summary.associate.with.${associateKind.formValue}"))


### PR DESCRIPTION
The SummaryList component renders an empty <span> element when no "actions" (change links) are required _if_ there are any rows in the List that _do_ have an action.

So the workaround is to split the two rows into two SummaryLists and add a css class on the first to reduce the space between them.

Visually, the two single-row lists look the same as the original. 