### PR TITLE
CEDS-2609 - manually render summary list to avoid <span> bug 

### DIFF
--- a/app/views/associateucr/associate_ucr_summary_no_change.scala.html
+++ b/app/views/associateucr/associate_ucr_summary_no_change.scala.html
@@ -25,7 +25,6 @@
     govukLayout: gds_main_template,
     govukButton: GovukButton,
     pageTitle: pageTitle,
-    govukSummaryList : GovukSummaryList,
     linkContent: linkContent,
     formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
@@ -46,6 +45,34 @@
     }
 }
 
+@summaryList = {
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                @messages("associate.ucr.summary.consignmentReference")
+            </dt>
+            <dd class="govuk-summary-list__value">
+                @consignmentRef
+            </dd>
+            <dd class="govuk-summary-list__actions"></dd>
+        </div>
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                @messages(s"associate.ucr.summary.associate.with.${associateKind.formValue}")
+            </dt>
+            <dd class="govuk-summary-list__value">
+                @associateWith
+            </dd>
+            <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="@changeUrl">
+                    <span aria-hidden="true">
+                        @messages("site.change")
+                    </span><span class="govuk-visually-hidden">@messages(s"site.change.hint.associate.${associateKind.formValue}")</span> </a>
+            </dd>
+        </div>
+    </dl>
+}
+
 @govukLayout(
     title = Title("associate.ucr.summary.title"),
     backButton = Some(BackButton(messages("site.back"), backCall))) {
@@ -54,38 +81,7 @@
 
         @pageTitle(messages("associate.ucr.summary.title"))
 
-        @govukSummaryList(SummaryList(
-            rows = Seq(
-                SummaryListRow(
-                    key = Key(
-                        content = Text(messages("associate.ucr.summary.consignmentReference"))
-                    ),
-                    value = Value(
-                        content = Text(consignmentRef)
-                    ),
-                    actions = None
-                ),
-                SummaryListRow(
-                    key = Key(
-                        content = Text(messages(s"associate.ucr.summary.associate.with.${associateKind.formValue}"))
-                    ),
-                    value = Value(
-                        content = Text(associateWith)
-                    ),
-                    actions = Some(Actions(
-                        items = Seq(
-                            ActionItem(
-                                href = changeUrl,
-                                content = HtmlContent(linkContent(messages("site.change"))),
-                                visuallyHiddenText = Some(messages(s"site.change.hint.associate.${associateKind.formValue}"))
-                            )
-                        )
-                    ))
-                )
-            ),
-            classes = "govuk-!-margin-bottom-9"
-        ))
-
+        @summaryList
 
         @govukButton(Button(content = Text(messages("site.confirmAndSubmit"))))
 


### PR DESCRIPTION
This is an alternative to https://github.com/hmrc/customs-movements-frontend/pull/282 which avoids having two summary lists