### PR TITLE
CEDS-2659 Upgrade SBT to 1.3.6

### DIFF
--- a/project/TestPhases.scala
+++ b/project/TestPhases.scala
@@ -1,9 +1,0 @@
-import sbt.Tests.{Group, SubProcess}
-import sbt.{ForkOptions, TestDefinition}
-
-object TestPhases {
-  def oneForkedJvmPerTest(tests: Seq[TestDefinition]): Seq[Group] =
-    tests map {
-      test => Group(test.name, Seq(test), SubProcess(ForkOptions(runJVMOptions = Seq("-Dtest.name=" + test.name))))
-    }
-}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.3.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,18 +1,18 @@
 resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.3.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.6.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.24")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.3")
 
@@ -22,10 +22,10 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.13")
 
-addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.1.9")
+addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.2.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % "2.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")

--- a/test/unit/services/SubmissionServiceSpec.scala
+++ b/test/unit/services/SubmissionServiceSpec.scala
@@ -51,6 +51,11 @@ class SubmissionServiceSpec extends UnitSpec with MovementsMetricsStub with Befo
   private val mucr = correctUcr_2
   private val ucr = correctUcr
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(audit, connector, repository, movementBuilder)
+  }
+
   override def afterEach(): Unit = {
     reset(audit, connector, repository, movementBuilder)
     super.afterEach()


### PR DESCRIPTION
This version seems to be the last reliable version.
Higher versions contain some issues with importing a project. That would
need additional steps and workarounds to make it work.