### PR TITLE
[CEDS-2745] Add feedback link to banner in all the pages

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -41,7 +41,7 @@ class AppConfig @Inject()(
     .map(uri => MongockConfig(uri))
 
   private lazy val contactFrontendBaseUrl = servicesConfig.baseUrl("contact-frontend")
-  private lazy val contactFrontendServiceIdentifier = loadConfig("microservice.services.contact-frontend.serviceId")
+  lazy val contactFrontendServiceIdentifier = loadConfig("microservice.services.contact-frontend.serviceId")
 
   lazy val keyStoreSource: String = appName
   lazy val keyStoreUrl: String = servicesConfig.baseUrl("keystore")

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -40,8 +40,8 @@ class AppConfig @Inject()(
     .getOptional[String]("mongodb.uri")
     .map(uri => MongockConfig(uri))
 
-  private lazy val contactBaseUrl = servicesConfig.baseUrl("contact-frontend")
-  private lazy val contactFrontendServiceIdentifier = loadConfig("microservice.services.contact-frontend.serviceIdentifier")
+  private lazy val contactFrontendBaseUrl = servicesConfig.baseUrl("contact-frontend")
+  private lazy val contactFrontendServiceIdentifier = loadConfig("microservice.services.contact-frontend.serviceId")
 
   lazy val keyStoreSource: String = appName
   lazy val keyStoreUrl: String = servicesConfig.baseUrl("keystore")
@@ -100,7 +100,7 @@ class AppConfig @Inject()(
   lazy val gtmContainer: String = servicesConfig.getString("tracking-consent-frontend.gtm.container")
 
   lazy val giveFeedbackLink: String =
-    s"$contactBaseUrl/contact/beta-feedback-unauthenticated?service=$contactFrontendServiceIdentifier"
+    s"$contactFrontendBaseUrl/contact/beta-feedback-unauthenticated?service=$contactFrontendServiceIdentifier"
 
   def languageMap: Map[String, Lang] =
     Map("english" -> Lang("en"), "cymraeg" -> Lang("cy"))

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -40,6 +40,9 @@ class AppConfig @Inject()(
     .getOptional[String]("mongodb.uri")
     .map(uri => MongockConfig(uri))
 
+  private lazy val contactBaseUrl = servicesConfig.baseUrl("contact-frontend")
+  private lazy val contactFrontendServiceIdentifier = loadConfig("microservice.services.contact-frontend.serviceIdentifier")
+
   lazy val keyStoreSource: String = appName
   lazy val keyStoreUrl: String = servicesConfig.baseUrl("keystore")
   lazy val sessionCacheDomain: String =
@@ -96,7 +99,9 @@ class AppConfig @Inject()(
 
   lazy val gtmContainer: String = servicesConfig.getString("tracking-consent-frontend.gtm.container")
 
+  lazy val giveFeedbackLink: String =
+    s"$contactBaseUrl/contact/beta-feedback-unauthenticated?service=$contactFrontendServiceIdentifier"
+
   def languageMap: Map[String, Lang] =
     Map("english" -> Lang("en"), "cymraeg" -> Lang("cy"))
-
 }

--- a/app/views/components/gds/phaseBanner.scala.html
+++ b/app/views/components/gds/phaseBanner.scala.html
@@ -15,13 +15,15 @@
  *@
 
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import config.AppConfig
 
-@this(govukPhaseBanner: GovukPhaseBanner)
+@this(govukPhaseBanner: GovukPhaseBanner, appConfig: AppConfig)
 
 @(phase: String)(implicit request: Request[_], messages: Messages)
 
+@protocol = @{if (request.secure) "https" else "http"}
 
-@link = {<a href="todo">@messages("feedback.link")</a>}
+@link = {<a href="@appConfig.giveFeedbackLink&backUrl=@protocol://@request.host@request.uri">@messages("feedback.link")</a>}
 @feedbackBanner = {
 @Html(messages("feedback", link))
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -103,6 +103,13 @@ microservice {
       ducrPart: enabled
       betaBanner: enabled
     }
+
+    contact-frontend {
+      protocol = http
+      host = localhost
+      port = 9250
+      serviceIdentifier = "customs-movements-frontend"
+    }
   }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -105,7 +105,6 @@ microservice {
     }
 
     contact-frontend {
-      protocol = http
       host = localhost
       port = 9250
       serviceId = "customs-movements-frontend"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -108,7 +108,7 @@ microservice {
       protocol = http
       host = localhost
       port = 9250
-      serviceIdentifier = "customs-movements-frontend"
+      serviceId = "customs-movements-frontend"
     }
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -107,7 +107,7 @@ microservice {
     contact-frontend {
       host = localhost
       port = 9250
-      serviceId = "customs-movements-frontend"
+      serviceId = "Exports-Movements"
     }
   }
 }

--- a/test/unit/views/PhaseBannerSpec.scala
+++ b/test/unit/views/PhaseBannerSpec.scala
@@ -17,6 +17,7 @@
 package views
 
 import base.Injector
+import config.AppConfig
 import play.api.test.FakeRequest
 import play.twirl.api.Html
 import views.html.components.gds.phaseBanner
@@ -24,6 +25,7 @@ import views.html.components.gds.phaseBanner
 class PhaseBannerSpec extends ViewSpec with Injector {
 
   private val banner = instanceOf[phaseBanner]
+  private val config = instanceOf[AppConfig]
 
   private val fakeRequestPath = "/customs-movements/start"
   private implicit val request = FakeRequest("GET", fakeRequestPath)
@@ -35,7 +37,7 @@ class PhaseBannerSpec extends ViewSpec with Injector {
 
     "display banner with the correct feedback link" in {
       banner.getElementsByClass("govuk-phase-banner__text").first().getElementsByTag("a").first() must haveHref(
-        s"http://localhost:9250/contact/beta-feedback-unauthenticated?service=customs-movements-frontend&backUrl=http://localhost$fakeRequestPath"
+        s"http://localhost:9250/contact/beta-feedback-unauthenticated?service=${config.contactFrontendServiceIdentifier}&backUrl=http://localhost$fakeRequestPath"
       )
     }
   }

--- a/test/unit/views/PhaseBannerSpec.scala
+++ b/test/unit/views/PhaseBannerSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.Injector
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import views.html.components.gds.phaseBanner
+
+class PhaseBannerSpec extends ViewSpec with Injector {
+
+  private val page = instanceOf[phaseBanner]
+
+  private val fakeRequestPath = "/customs-movements/start"
+  private implicit val request = FakeRequest("GET", fakeRequestPath)
+
+  private def createBanner(): Html = page("")(request, messages)
+
+  "Phase banner" should {
+    val banner = createBanner()
+
+    "display banner with the correct feedback link" in {
+      banner.getElementsByClass("govuk-phase-banner__text").first().getElementsByTag("a").first() must haveHref(
+        s"http://localhost:9250/contact/beta-feedback-unauthenticated?service=customs-movements-frontend&backUrl=http://localhost$fakeRequestPath"
+      )
+    }
+  }
+}

--- a/test/unit/views/PhaseBannerSpec.scala
+++ b/test/unit/views/PhaseBannerSpec.scala
@@ -23,12 +23,12 @@ import views.html.components.gds.phaseBanner
 
 class PhaseBannerSpec extends ViewSpec with Injector {
 
-  private val page = instanceOf[phaseBanner]
+  private val banner = instanceOf[phaseBanner]
 
   private val fakeRequestPath = "/customs-movements/start"
   private implicit val request = FakeRequest("GET", fakeRequestPath)
 
-  private def createBanner(): Html = page("")(request, messages)
+  private def createBanner(): Html = banner("")(request, messages)
 
   "Phase banner" should {
     val banner = createBanner()


### PR DESCRIPTION
As a part of Public Beta Readiness prep activities, every page
of the External Movements must have a feedback link at the
top left corner under black GOV.UK banner and next to BETA
blue box.

This sends the feedback to Splunk for later retrieval.