### PR TITLE
CEDS-2667 Add HMRCReportTechnicalssue component

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -28,7 +28,7 @@ class AppConfig @Inject()(
   val runModeConfiguration: Configuration,
   val environment: Environment,
   servicesConfig: ServicesConfig,
-  @Named("appName") appName: String
+  @Named("appName") namedAppName: String
 ) {
 
   private def loadConfig(key: String): String =
@@ -43,7 +43,7 @@ class AppConfig @Inject()(
   private lazy val contactFrontendBaseUrl = servicesConfig.baseUrl("contact-frontend")
   lazy val contactFrontendServiceIdentifier = loadConfig("microservice.services.contact-frontend.serviceId")
 
-  lazy val keyStoreSource: String = appName
+  lazy val appName: String = namedAppName
   lazy val keyStoreUrl: String = servicesConfig.baseUrl("keystore")
   lazy val sessionCacheDomain: String =
     servicesConfig.getConfString("cachable.session-cache.domain", throw new Exception(s"Could not find config 'cachable.session-cache.domain'"))

--- a/app/views/components/gds/gds_main_template.scala.html
+++ b/app/views/components/gds/gds_main_template.scala.html
@@ -21,6 +21,9 @@
 @import components.gds.{phaseBanner, siteHeader}
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
+@import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcReportTechnicalIssue
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.reporttechnicalissue.ReportTechnicalIssue
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{En, Cy}
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcTrackingConsentSnippet
 @import views.Title
 @import views.components.BackButton
@@ -35,7 +38,9 @@
   phaseBanner: phaseBanner,
   timeoutDialogConfig: TimeoutDialogConfig,
   betaBannerConfig: BetaBannerConfig,
-  hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet
+  hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet,
+  hmrcReportTechnicalIssue: HmrcReportTechnicalIssue,
+  appConfig: AppConfig
 )
 
 @(
@@ -63,6 +68,7 @@
 
   @if(useTimeoutDialog) {
       <script src='@routes.Assets.versioned("lib/hmrc-frontend/hmrc/all.js")'></script>
+      <script>window.HMRCFrontend.initAll();</script>
       <script src='@routes.Assets.versioned("javascripts/timeoutDialog.js")'> </script>
   }
 
@@ -89,6 +95,12 @@
         )))
     </div>
     @contentBlock
+    @hmrcReportTechnicalIssue(
+        ReportTechnicalIssue(
+            serviceCode = appConfig.keyStoreSource,
+            language = if(messages.lang.code == "en") En else Cy)
+    )
+
 }
 @footer = @{
     Seq(

--- a/app/views/components/gds/gds_main_template.scala.html
+++ b/app/views/components/gds/gds_main_template.scala.html
@@ -97,7 +97,7 @@
     @contentBlock
     @hmrcReportTechnicalIssue(
         ReportTechnicalIssue(
-            serviceCode = appConfig.keyStoreSource,
+            serviceCode = appConfig.appName,
             language = if(messages.lang.code == "en") En else Cy)
     )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -13,7 +13,7 @@ object AppDependencies {
     "uk.gov.hmrc"          %% "play-ui"                       % "8.14.0-play-26",
     "uk.gov.hmrc"          %% "bootstrap-frontend-play-26"    % "2.24.0",
     "uk.gov.hmrc"          %% "play-frontend-govuk"           % "0.53.0-play-26",
-    "uk.gov.hmrc"          %% "play-frontend-hmrc"            % "0.23.0-play-26",
+    "uk.gov.hmrc"          %% "play-frontend-hmrc"            % "0.26.0-play-26",
     "ai.x"                 %% "play-json-extensions"          % "0.42.0",
     "uk.gov.hmrc"          %% "play-whitelist-filter"         % "3.4.0-play-26",
     "uk.gov.hmrc"          %% "simple-reactivemongo"          % "7.30.0-play-26",
@@ -22,7 +22,7 @@ object AppDependencies {
     "com.github.cloudyrock.mongock"  %  "mongock-core"        % "2.0.2",
     "org.mongodb"          %  "mongo-java-driver"             % "3.12.1",
     "org.webjars.npm"      %  "govuk-frontend"                % "3.9.1",
-    "org.webjars.npm"      %  "hmrc-frontend"                 % "1.19.0",
+    "org.webjars.npm"      %  "hmrc-frontend"                 % "1.20.0",
     "org.webjars.npm"      %  "accessible-autocomplete"       % "2.0.3"
   )
 

--- a/test/unit/views/associateucr/AssociateUcrSummaryViewSpec.scala
+++ b/test/unit/views/associateucr/AssociateUcrSummaryViewSpec.scala
@@ -69,7 +69,7 @@ class AssociateUcrSummaryViewSpec extends ViewSpec with Injector {
 
     "display 'Change' link on the page for mucr" in {
 
-      val changeMucr = view.getElementsByClass("govuk-link").last()
+      val changeMucr = view.getElementsByClass("govuk-link").get(2)
       changeMucr must containMessage("site.change")
       changeMucr must haveHref(controllers.consolidations.routes.MucrOptionsController.displayPage())
     }

--- a/test/unit/views/associateucr/MucrOptionsViewSpec.scala
+++ b/test/unit/views/associateucr/MucrOptionsViewSpec.scala
@@ -47,7 +47,7 @@ class MucrOptionsViewSpec extends ViewSpec with MockitoSugar with BeforeAndAfter
     when(ileQueryConfig.isIleQueryEnabled).thenReturn(true)
     when(appConfig.tradeTariffUrl).thenReturn(tradeTariffUrl)
     when(appConfig.gtmContainer).thenReturn("a")
-    when(appConfig.keyStoreSource).thenReturn("app-name")
+    when(appConfig.appName).thenReturn("app-name")
   }
 
   override def afterEach(): Unit = {

--- a/test/unit/views/associateucr/MucrOptionsViewSpec.scala
+++ b/test/unit/views/associateucr/MucrOptionsViewSpec.scala
@@ -47,6 +47,7 @@ class MucrOptionsViewSpec extends ViewSpec with MockitoSugar with BeforeAndAfter
     when(ileQueryConfig.isIleQueryEnabled).thenReturn(true)
     when(appConfig.tradeTariffUrl).thenReturn(tradeTariffUrl)
     when(appConfig.gtmContainer).thenReturn("a")
+    when(appConfig.keyStoreSource).thenReturn("app-name")
   }
 
   override def afterEach(): Unit = {

--- a/test/unit/views/disassociateucr/DisassociateUcrSummaryViewSpec.scala
+++ b/test/unit/views/disassociateucr/DisassociateUcrSummaryViewSpec.scala
@@ -83,7 +83,7 @@ class DisassociateUcrSummaryViewSpec extends ViewSpec with MockitoSugar with Bef
 
       val links = page(disassociateUcr).getElementsByClass("govuk-link")
 
-      links.size() mustBe 1
+      links.size() mustBe 2
     }
 
     "have 'Back' button when ileQuery enabled" in {

--- a/test/unit/views/shutmucr/ShutMucrSummaryViewSpec.scala
+++ b/test/unit/views/shutmucr/ShutMucrSummaryViewSpec.scala
@@ -80,7 +80,7 @@ class ShutMucrSummaryViewSpec extends ViewSpec with MockitoSugar with BeforeAndA
 
       when(ileQueryConfig.isIleQueryEnabled).thenReturn(true)
 
-      shutMucrSummaryPage(shutMucr).getElementsByClass("govuk-link").size() mustBe 1
+      shutMucrSummaryPage(shutMucr).getElementsByClass("govuk-link").size() mustBe 2
     }
 
     "display correct change button when ileQuery disabled" in {


### PR DESCRIPTION
This component is a non-ajax implementation and is the recommended
approach by the HMRC Play UI team, since the previous "GetHelpLink" was
not accessible.

This component does not work locally and it should simply open a new
page. We have been told that this will work in all the other
environments.