### PR TITLE
CEDS-2745 Fix contact-frontend url

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -40,9 +40,6 @@ class AppConfig @Inject()(
     .getOptional[String]("mongodb.uri")
     .map(uri => MongockConfig(uri))
 
-  private lazy val contactFrontendUrl = loadConfig("microservice.services.contact-frontend.url")
-  lazy val contactFrontendServiceIdentifier = loadConfig("microservice.services.contact-frontend.serviceId")
-
   lazy val appName: String = namedAppName
   lazy val keyStoreUrl: String = servicesConfig.baseUrl("keystore")
   lazy val sessionCacheDomain: String =
@@ -59,6 +56,14 @@ class AppConfig @Inject()(
   lazy val serviceAvailabilityUrl = loadConfig("urls.serviceAvailability")
 
   lazy val customsDeclareExportsMovements = servicesConfig.baseUrl("customs-declare-exports-movements")
+
+  lazy val selfBaseUrl: Option[String] = runModeConfiguration.getOptional[String]("platform.frontend.host")
+  lazy val giveFeedbackLink: String = {
+    val contactFrontendUrl = loadConfig("microservice.services.contact-frontend.url")
+    val contactFrontendServiceIdentifier: String = loadConfig("microservice.services.contact-frontend.serviceId")
+
+    s"$contactFrontendUrl?service=$contactFrontendServiceIdentifier"
+  }
 
   lazy val movementsSubmissionUri = servicesConfig.getConfString(
     "customs-declare-exports-movements.submit-movements",
@@ -98,8 +103,6 @@ class AppConfig @Inject()(
       .getOrElse(true)
 
   lazy val gtmContainer: String = servicesConfig.getString("tracking-consent-frontend.gtm.container")
-
-  lazy val giveFeedbackLink: String = s"$contactFrontendUrl?service=$contactFrontendServiceIdentifier"
 
   def languageMap: Map[String, Lang] =
     Map("english" -> Lang("en"), "cymraeg" -> Lang("cy"))

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -40,7 +40,7 @@ class AppConfig @Inject()(
     .getOptional[String]("mongodb.uri")
     .map(uri => MongockConfig(uri))
 
-  private lazy val contactFrontendBaseUrl = servicesConfig.baseUrl("contact-frontend")
+  private lazy val contactFrontendUrl = loadConfig("microservice.services.contact-frontend.url")
   lazy val contactFrontendServiceIdentifier = loadConfig("microservice.services.contact-frontend.serviceId")
 
   lazy val appName: String = namedAppName
@@ -99,8 +99,7 @@ class AppConfig @Inject()(
 
   lazy val gtmContainer: String = servicesConfig.getString("tracking-consent-frontend.gtm.container")
 
-  lazy val giveFeedbackLink: String =
-    s"$contactFrontendBaseUrl/contact/beta-feedback-unauthenticated?service=$contactFrontendServiceIdentifier"
+  lazy val giveFeedbackLink: String = s"$contactFrontendUrl?service=$contactFrontendServiceIdentifier"
 
   def languageMap: Map[String, Lang] =
     Map("english" -> Lang("en"), "cymraeg" -> Lang("cy"))

--- a/app/views/components/gds/phaseBanner.scala.html
+++ b/app/views/components/gds/phaseBanner.scala.html
@@ -21,7 +21,10 @@
 
 @(phase: String)(implicit request: Request[_], messages: Messages)
 
-@link = {<a href="@appConfig.giveFeedbackLink&backURL=@request.uri">@messages("feedback.link")</a>}
+@backUrl = @{ appConfig.selfBaseUrl.map(url => s"&backUrl=$url${request.uri}").getOrElse("") }
+@betaFeedbackUrl = @{s"${appConfig.giveFeedbackLink}$backUrl"}
+@link = {<a href="@betaFeedbackUrl">@messages("feedback.link")</a>}
+
 @feedbackBanner = {
   @Html(messages("feedback", link))
 }

--- a/app/views/components/gds/phaseBanner.scala.html
+++ b/app/views/components/gds/phaseBanner.scala.html
@@ -21,11 +21,9 @@
 
 @(phase: String)(implicit request: Request[_], messages: Messages)
 
-@protocol = @{if (request.secure) "https" else "http"}
-
-@link = {<a href="@appConfig.giveFeedbackLink&backUrl=@protocol://@request.host@request.uri">@messages("feedback.link")</a>}
+@link = {<a href="@appConfig.giveFeedbackLink&backURL=@request.uri">@messages("feedback.link")</a>}
 @feedbackBanner = {
-@Html(messages("feedback", link))
+  @Html(messages("feedback", link))
 }
 
 @govukPhaseBanner(PhaseBanner(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -167,3 +167,6 @@ timeoutDialog {
 tracking-consent-frontend {
   gtm.container = "a"
 }
+
+# Default value for local environment
+platform.frontend.host = "http://localhost:6791"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -105,8 +105,7 @@ microservice {
     }
 
     contact-frontend {
-      host = localhost
-      port = 9250
+      url = "http://localhost:9250/contact/beta-feedback-unauthenticated"
       serviceId = "Exports-Movements"
     }
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -169,4 +169,4 @@ tracking-consent-frontend {
 }
 
 # Default value for local environment
-platform.frontend.host = "http://localhost:6791"
+platform.frontend.host = "http://localhost:6796"

--- a/run-contact-frontend-sm_local.sh
+++ b/run-contact-frontend-sm_local.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sm --stop CONTACT_FRONTEND
+sm --start CONTACT --appendArgs '{"CONTACT_FRONTEND":["-DbackUrlDestinationWhitelist=http://localhost:6791,http://localhost:6793,http://localhost:6796"]}'

--- a/test/unit/config/AppConfigSpec.scala
+++ b/test/unit/config/AppConfigSpec.scala
@@ -60,6 +60,9 @@ class AppConfigSpec extends WordSpec with MustMatchers with MockitoSugar {
         |
         |microservice.services.customs-declare-exports-movements.submit-movements=/movements
         |microservice.services.customs-declare-exports-movements.submit-consolidation=/consolidation
+        |
+        |microservice.services.contact-frontend.url=/contact-frontend-url
+        |microservice.services.contact-frontend.serviceId=Movements-Service-ID
       """.stripMargin
     )
   private val emptyAppConfig: Config = ConfigFactory.parseString("")
@@ -150,66 +153,80 @@ class AppConfigSpec extends WordSpec with MustMatchers with MockitoSugar {
       validConfigService.fetchNotifications must be("/notifications")
     }
 
-  }
+    "have feedback link" in {
+      validConfigService.giveFeedbackLink must be("/contact-frontend-url?service=Movements-Service-ID")
+    }
 
-  "throw an exception when google-analytics.host is missing" in {
-    intercept[Exception](emptyConfigService.analyticsHost).getMessage must be("Missing configuration key: google-analytics.host")
-  }
+    "throw an exception" when {
 
-  "throw an exception when gtm.container is missing" in {
-    intercept[Exception](emptyConfigService.gtmContainer).getMessage must be("Could not find config key 'tracking-consent-frontend.gtm.container'")
-  }
+      "google-analytics.host is missing" in {
+        intercept[Exception](emptyConfigService.analyticsHost).getMessage must be("Missing configuration key: google-analytics.host")
+      }
 
-  "throw an exception when google-analytics.token is missing" in {
-    intercept[Exception](emptyConfigService.analyticsToken).getMessage must be("Missing configuration key: google-analytics.token")
-  }
+      "gtm.container is missing" in {
+        intercept[Exception](emptyConfigService.gtmContainer).getMessage must be(
+          "Could not find config key 'tracking-consent-frontend.gtm.container'"
+        )
+      }
 
-  "throw an exception when auth.host is missing" in {
-    intercept[Exception](emptyConfigService.authUrl).getMessage must be("Could not find config key 'auth.host'")
-  }
+      "google-analytics.token is missing" in {
+        intercept[Exception](emptyConfigService.analyticsToken).getMessage must be("Missing configuration key: google-analytics.token")
+      }
 
-  "throw an exception when urls.login is missing" in {
-    intercept[Exception](emptyConfigService.loginUrl).getMessage must be("Missing configuration key: urls.login")
-  }
+      "auth.host is missing" in {
+        intercept[Exception](emptyConfigService.authUrl).getMessage must be("Could not find config key 'auth.host'")
+      }
 
-  "throw an exception when urls.loginContinue is missing" in {
-    intercept[Exception](emptyConfigService.loginContinueUrl).getMessage must be("Missing configuration key: urls.loginContinue")
-  }
+      "urls.login is missing" in {
+        intercept[Exception](emptyConfigService.loginUrl).getMessage must be("Missing configuration key: urls.login")
+      }
 
-  "throw an exception when customs-declare-exports-movements.host is missing" in {
-    intercept[Exception](emptyConfigService.customsDeclareExportsMovements).getMessage must be(
-      "Could not find config key 'customs-declare-exports-movements.host'"
-    )
-  }
+      "urls.loginContinue is missing" in {
+        intercept[Exception](emptyConfigService.loginContinueUrl).getMessage must be("Missing configuration key: urls.loginContinue")
+      }
 
-  "throw an exception when movement Arrival submission uri is missing" in {
-    intercept[Exception](emptyConfigService.movementsSubmissionUri).getMessage must be(
-      "Missing configuration for Customs Declarations Exports Movements submission URI"
-    )
-  }
+      "customs-declare-exports-movements.host is missing" in {
+        intercept[Exception](emptyConfigService.customsDeclareExportsMovements).getMessage must be(
+          "Could not find config key 'customs-declare-exports-movements.host'"
+        )
+      }
 
-  "throw an exception when consolidation submission uri is missing" in {
-    intercept[Exception](emptyConfigService.movementConsolidationUri).getMessage must be(
-      "Missing configuration for Customs Declarations Exports Movements Consolidation"
-    )
-  }
+      "movement Arrival submission uri is missing" in {
+        intercept[Exception](emptyConfigService.movementsSubmissionUri).getMessage must be(
+          "Missing configuration for Customs Declarations Exports Movements submission URI"
+        )
+      }
 
-  "throw an exception when fetch all submissions uri is missing" in {
-    intercept[Exception](emptyConfigService.fetchAllSubmissions).getMessage must be(
-      "Missing configuration for Customs Declaration Exports fetch all submission URI"
-    )
-  }
+      "consolidation submission uri is missing" in {
+        intercept[Exception](emptyConfigService.movementConsolidationUri).getMessage must be(
+          "Missing configuration for Customs Declarations Exports Movements Consolidation"
+        )
+      }
 
-  "throw an exception when fetch single submission uri is missing" in {
-    intercept[Exception](emptyConfigService.fetchSingleSubmission).getMessage must be(
-      "Missing configuration for Customs Declaration Exports fetch single submission URI"
-    )
-  }
+      "fetch all submissions uri is missing" in {
+        intercept[Exception](emptyConfigService.fetchAllSubmissions).getMessage must be(
+          "Missing configuration for Customs Declaration Exports fetch all submission URI"
+        )
+      }
 
-  "throw an exception when fetch notifications uri is missing" in {
-    intercept[Exception](emptyConfigService.fetchNotifications).getMessage must be(
-      "Missing configuration for Customs Declarations Exports fetch notifications URI"
-    )
+      "fetch single submission uri is missing" in {
+        intercept[Exception](emptyConfigService.fetchSingleSubmission).getMessage must be(
+          "Missing configuration for Customs Declaration Exports fetch single submission URI"
+        )
+      }
+
+      "fetch notifications uri is missing" in {
+        intercept[Exception](emptyConfigService.fetchNotifications).getMessage must be(
+          "Missing configuration for Customs Declarations Exports fetch notifications URI"
+        )
+      }
+
+      "fetch giveFeedbackLink is missing" in {
+        intercept[Exception](emptyConfigService.giveFeedbackLink).getMessage must be(
+          "Missing configuration key: microservice.services.contact-frontend.url"
+        )
+      }
+    }
   }
 
 }

--- a/test/unit/config/AppConfigSpec.scala
+++ b/test/unit/config/AppConfigSpec.scala
@@ -63,6 +63,7 @@ class AppConfigSpec extends WordSpec with MustMatchers with MockitoSugar {
         |
         |microservice.services.contact-frontend.url=/contact-frontend-url
         |microservice.services.contact-frontend.serviceId=Movements-Service-ID
+        |platform.frontend.host="self/base-url"
       """.stripMargin
     )
   private val emptyAppConfig: Config = ConfigFactory.parseString("")
@@ -153,8 +154,17 @@ class AppConfigSpec extends WordSpec with MustMatchers with MockitoSugar {
       validConfigService.fetchNotifications must be("/notifications")
     }
 
+    "have selfBaseUrl" in {
+      validConfigService.selfBaseUrl must be(defined)
+      validConfigService.selfBaseUrl.get must be("self/base-url")
+    }
+
     "have feedback link" in {
       validConfigService.giveFeedbackLink must be("/contact-frontend-url?service=Movements-Service-ID")
+    }
+
+    "empty selfBaseUrl when the key is missing" in {
+      emptyConfigService.selfBaseUrl must be(None)
     }
 
     "throw an exception" when {

--- a/test/unit/views/PhaseBannerSpec.scala
+++ b/test/unit/views/PhaseBannerSpec.scala
@@ -37,7 +37,7 @@ class PhaseBannerSpec extends ViewSpec with Injector {
 
     "display banner with the correct feedback link" in {
       banner.getElementsByClass("govuk-phase-banner__text").first().getElementsByTag("a").first() must haveHref(
-        s"http://localhost:9250/contact/beta-feedback-unauthenticated?service=${config.contactFrontendServiceIdentifier}&backUrl=http://localhost$fakeRequestPath"
+        s"http://localhost:9250/contact/beta-feedback-unauthenticated?service=${config.contactFrontendServiceIdentifier}&backURL=$fakeRequestPath"
       )
     }
   }

--- a/test/unit/views/associateucr/MucrOptionsViewSpec.scala
+++ b/test/unit/views/associateucr/MucrOptionsViewSpec.scala
@@ -17,7 +17,7 @@
 package views.associateucr
 
 import base.OverridableInjector
-import config.{AppConfig, IleQueryConfig}
+import config.IleQueryConfig
 import forms.UcrType.Mucr
 import forms.{ManageMucrChoice, MucrOptions}
 import models.UcrBlock
@@ -34,22 +34,14 @@ import views.html.associateucr.mucr_options
 class MucrOptionsViewSpec extends ViewSpec with MockitoSugar with BeforeAndAfterEach {
 
   private val ileQueryConfig = mock[IleQueryConfig]
-  private val appConfig = mock[AppConfig]
-  private val injector = new OverridableInjector(bind[AppConfig].toInstance(appConfig), bind[IleQueryConfig].toInstance(ileQueryConfig))
+  private val injector = new OverridableInjector(bind[IleQueryConfig].toInstance(ileQueryConfig))
 
   private val page = injector.instanceOf[mucr_options]
-
-  private val tradeTariffUrl = "http://trade-tariff"
 
   override def beforeEach(): Unit = {
     super.beforeEach()
 
     when(ileQueryConfig.isIleQueryEnabled).thenReturn(true)
-    when(appConfig.tradeTariffUrl).thenReturn(tradeTariffUrl)
-    when(appConfig.gtmContainer).thenReturn("a")
-    when(appConfig.appName).thenReturn("app-name")
-    when(appConfig.selfBaseUrl).thenReturn(Some("selfBaseUrlTest"))
-    when(appConfig.giveFeedbackLink).thenReturn("giveFeedbackLinkTest")
   }
 
   override def afterEach(): Unit = {
@@ -81,7 +73,7 @@ class MucrOptionsViewSpec extends ViewSpec with MockitoSugar with BeforeAndAfter
       val hint = createView().getElementById("createOrAdd-hint")
 
       hint must containMessage("mucrOptions.hint", messages("mucrOptions.hint.link"))
-      hint.getElementsByTag("a").first() must haveHref(tradeTariffUrl)
+      hint.getElementsByTag("a").first() must haveHref("https://www.gov.uk/trade-tariff")
     }
 
     "render the correct labels and hints" in {

--- a/test/unit/views/associateucr/MucrOptionsViewSpec.scala
+++ b/test/unit/views/associateucr/MucrOptionsViewSpec.scala
@@ -48,6 +48,8 @@ class MucrOptionsViewSpec extends ViewSpec with MockitoSugar with BeforeAndAfter
     when(appConfig.tradeTariffUrl).thenReturn(tradeTariffUrl)
     when(appConfig.gtmContainer).thenReturn("a")
     when(appConfig.appName).thenReturn("app-name")
+    when(appConfig.selfBaseUrl).thenReturn(Some("selfBaseUrlTest"))
+    when(appConfig.giveFeedbackLink).thenReturn("giveFeedbackLinkTest")
   }
 
   override def afterEach(): Unit = {


### PR DESCRIPTION
There are 2 issues that are fixed in this PR:
1. `backURL` should have capitalized 'URL'
2. In other environments, the link to contact-frontend was incorrect.
    It should be using url, similarly to how we link to Movements in
    Declarations service.
