### PR TITLE
[CEDS-2947] Updating Validation Error Messages Additional work

### DIFF
--- a/app/controllers/consolidations/MucrOptionsController.scala
+++ b/app/controllers/consolidations/MucrOptionsController.scala
@@ -52,17 +52,12 @@ class MucrOptionsController @Inject()(
       .fold(
         formWithErrors => Future.successful(BadRequest(buildPage(formWithErrors))),
         validForm => {
-          val validatedForm = MucrOptions.validateForm(form.fill(validForm))
-          if (validatedForm.hasErrors) {
-            Future.successful(BadRequest(buildPage(validatedForm)))
-          } else {
-            val updatedAnswers = request.answersAs[AssociateUcrAnswers].copy(mucrOptions = Some(validForm))
-            cacheRepository.upsert(request.cache.update(updatedAnswers)).map { _ =>
-              if (request.cache.queryUcr.isDefined)
-                Redirect(routes.AssociateUcrSummaryController.displayPage())
-              else
-                Redirect(routes.AssociateUcrController.displayPage())
-            }
+          val updatedAnswers = request.answersAs[AssociateUcrAnswers].copy(mucrOptions = Some(validForm))
+          cacheRepository.upsert(request.cache.update(updatedAnswers)).map { _ =>
+            if (request.cache.queryUcr.isDefined)
+              Redirect(routes.AssociateUcrSummaryController.displayPage())
+            else
+              Redirect(routes.AssociateUcrController.displayPage())
           }
         }
       )

--- a/app/forms/AssociateUcr.scala
+++ b/app/forms/AssociateUcr.scala
@@ -48,8 +48,20 @@ object AssociateUcr {
 
     Forms.mapping(
       "kind" -> of[UcrType](UcrType.formatter),
-      "ducr" -> mandatoryIfEqual("kind", Ducr.formValue, text().verifying("ducr.error.format", validDucrIgnoreCase)),
-      "mucr" -> mandatoryIfEqual("kind", Mucr.formValue, text().verifying("mucr.error.format", validMucrIgnoreCase))
+      "ducr" -> mandatoryIfEqual(
+        "kind",
+        Ducr.formValue,
+        text()
+          .verifying("associate.ucr.ducr.error.empty", nonEmpty)
+          .verifying("associate.ucr.ducr.error.invalid", isEmpty or validDucrIgnoreCase)
+      ),
+      "mucr" -> mandatoryIfEqual(
+        "kind",
+        Mucr.formValue,
+        text()
+          .verifying("associate.ucr.mucr.error.empty", nonEmpty)
+          .verifying("associate.ucr.mucr.error.invalid", isEmpty or validMucrIgnoreCase)
+      )
     )(bind)(unbind)
   }
 

--- a/app/forms/DucrPartDetails.scala
+++ b/app/forms/DucrPartDetails.scala
@@ -21,7 +21,7 @@ import models.UcrBlock
 import play.api.data.Forms._
 import play.api.data.{Form, Forms, Mapping}
 import play.api.libs.json.{Json, OFormat}
-import utils.validators.forms.FieldValidator.{isValidDucrPartId, validDucrIgnoreCase}
+import utils.validators.forms.FieldValidator._
 
 case class DucrPartDetails(ducr: String, ducrPartId: String) {
 
@@ -51,8 +51,12 @@ object DucrPartDetails {
     def bind(ducr: String, ducrPartId: String): DucrPartDetails = DucrPartDetails(ducr.toUpperCase, ducrPartId.toUpperCase)
 
     Forms.mapping(
-      "ducr" -> text().verifying("ducrPartDetails.ducr.error", validDucrIgnoreCase),
-      "ducrPartId" -> text().verifying("ducrPartDetails.ducrPartId.error", isValidDucrPartId)
+      "ducr" -> text()
+        .verifying("ducrPartDetails.ducr.empty", nonEmpty)
+        .verifying("ducrPartDetails.ducr.invalid", isEmpty or validDucrIgnoreCase),
+      "ducrPartId" -> text()
+        .verifying("ducrPartDetails.ducrPartId.empty", nonEmpty)
+        .verifying("ducrPartDetails.ducrPartId.invalid", isEmpty or isValidDucrPartId)
     )(bind)(unapply)
   }
 

--- a/app/forms/MucrOptions.scala
+++ b/app/forms/MucrOptions.scala
@@ -16,18 +16,15 @@
 
 package forms
 
+import forms.EnhancedMapping.requiredRadio
 import models.UcrBlock
 import play.api.data.Forms._
 import play.api.data.{Form, Forms}
 import play.api.libs.json.Json
+import uk.gov.voa.play.form.ConditionalMappings.mandatoryIfEqual
 import utils.validators.forms.FieldValidator._
 
-case class MucrOptions(newMucr: String = "", existingMucr: String = "", createOrAdd: String = MucrOptions.Create) {
-  def mucr: String = createOrAdd match {
-    case MucrOptions.Create => newMucr
-    case MucrOptions.Add    => existingMucr
-  }
-}
+case class MucrOptions(createOrAdd: String, mucr: String)
 
 object MucrOptions {
 
@@ -40,37 +37,42 @@ object MucrOptions {
 
   def apply(ucrBlock: UcrBlock): MucrOptions =
     ucrBlock.ucrType match {
-      case UcrType.Mucr.codeValue => MucrOptions("", ucrBlock.ucr, MucrOptions.Add)
+      case UcrType.Mucr.codeValue => MucrOptions(MucrOptions.Add, ucrBlock.ucr)
       case _                      => throw new IllegalArgumentException(s"Invalid ucrType: ${ucrBlock.ucrType}")
     }
 
-  def form2Model: (String, String, String) => MucrOptions = {
-    case (createOrAdd, newMucr, existingMucr) =>
-      createOrAdd match {
-        case Create => MucrOptions(newMucr.toUpperCase, "", Create)
-        case Add    => MucrOptions("", existingMucr.toUpperCase, Add)
+  val mapping = {
+    def bind(creatOrAdd: String, newMucr: Option[String], existingMucr: Option[String]): MucrOptions =
+      creatOrAdd match {
+        case Create => MucrOptions(Create, newMucr.getOrElse("").toUpperCase)
+        case Add    => MucrOptions(Add, existingMucr.getOrElse("").toUpperCase)
       }
+
+    def unbind(value: MucrOptions): Option[(String, Option[String], Option[String])] =
+      value.createOrAdd match {
+        case Create => Some((Create, Some(value.mucr), None))
+        case Add    => Some((Add, None, Some(value.mucr)))
+      }
+
+    Forms
+      .mapping(
+        "createOrAdd" -> requiredRadio("mucrOptions.error.unselected"),
+        "newMucr" -> mandatoryIfEqual(
+          "createOrAdd",
+          Create,
+          text()
+            .verifying("mucrOptions.reference.value.error.empty", nonEmpty)
+            .verifying("mucrOptions.reference.value.error.invalid", isEmpty or validMucrIgnoreCase)
+        ),
+        "existingMucr" -> mandatoryIfEqual(
+          "createOrAdd",
+          Add,
+          text()
+            .verifying("mucrOptions.reference.value.error.empty", nonEmpty)
+            .verifying("mucrOptions.reference.value.error.invalid", isEmpty or validMucrIgnoreCase)
+        )
+      )(bind)(unbind)
   }
 
-  def model2Form: MucrOptions => Option[(String, String, String)] =
-    m => Some((m.createOrAdd, m.newMucr, m.existingMucr))
-
-  val mapping =
-    Forms
-      .mapping("createOrAdd" -> text().verifying("mucrOptions.createAdd.value.empty", nonEmpty), "newMucr" -> text(), "existingMucr" -> text())(
-        form2Model
-      )(model2Form)
-
   val form: Form[MucrOptions] = Form(mapping)
-
-  def validateForm(form: Form[MucrOptions]): Form[MucrOptions] =
-    if (form.value.exists(op => validMucrIgnoreCase(op.mucr))) {
-      form
-    } else {
-      val errorField = form.value.map(_.createOrAdd) match {
-        case Some(Create) => "newMucr"
-        case _            => "existingMucr"
-      }
-      form.withError(errorField, "mucrOptions.reference.value.error")
-    }
 }

--- a/app/forms/UcrType.scala
+++ b/app/forms/UcrType.scala
@@ -35,12 +35,14 @@ object UcrType {
     case DucrPart.formValue => DucrPart
   }
 
+  private val noRadioSelectedErrorKey = "associate.ucr.error.unselected"
+
   val formatter: Formatter[UcrType] = new Formatter[UcrType] {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], UcrType] = {
       data.get(key).map { typ =>
-        lookup.andThen(Right.apply).applyOrElse(typ, (_: String) => Left(Seq(FormError(key, "error.unknown"))))
+        lookup.andThen(Right.apply).applyOrElse(typ, (_: String) => Left(Seq(FormError(key, noRadioSelectedErrorKey))))
       }
-    }.getOrElse(Left(Seq(FormError(key, "error.required"))))
+    }.getOrElse(Left(Seq(FormError(key, noRadioSelectedErrorKey))))
 
     override def unbind(key: String, value: UcrType): Map[String, String] = Map(key -> value.formValue)
   }

--- a/app/views/components/gds/exportsInputText.scala.html
+++ b/app/views/components/gds/exportsInputText.scala.html
@@ -30,7 +30,7 @@
 @buildLabel = @{ if(isPageHeading) {
     Label(content = Text(messages(labelKey)), isPageHeading = true,  classes = headingClasses)
   } else {
-    Label(content = Text(messages(labelKey)))
+    Label(content = Text(messages(labelKey)), classes = "govuk-label govuk-label--m")
   }
 }
 

--- a/conf/messages
+++ b/conf/messages
@@ -109,7 +109,7 @@ startPage.informationYouNeed.listItem.3 = the Master Unique Consignment Referenc
 startPage.informationYouNeed.listItem.4 = details of where you’re sending the export to and from
 startPage.reportYourArrivalAndDeparture.header = Report your arrival and departure
 startPage.problemsWithServiceNotice = Online services may be slow during busy times. Check if there are any {0}
-startPage.problemsWithServiceNotice.link = problems with this service.
+startPage.problemsWithServiceNotice.link = problems with this service
 startPage.buttonName = Start now
 
 choicePage.input.error.empty = Select the option you want
@@ -123,13 +123,13 @@ consignmentReferences.reference.ducr = Declaration Consignment Reference (DUCR)
 consignmentReferences.reference.mucr = Master Consignment Reference (MUCR)
 consignmentReferences.reference.ducrPart = DUCR Part
 consignmentReferences.reference.empty = Select a declaration
-consignmentReferences.reference.error = Incorrect reference.
+consignmentReferences.reference.error = Incorrect reference
 consignmentReferences.reference.ducrValue = Declaration Unique Consignment Reference
 consignmentReferences.reference.mucrValue = Master Unique Consignment Reference
-consignmentReferences.reference.mucrValue.empty = Enter a Master Unique Consignment Reference.
-consignmentReferences.reference.ducrValue.empty = Enter a Declaration Unique Consignment Reference.
-consignmentReferences.reference.mucrValue.error = Master Unique Consignment Reference is incorrect.
-consignmentReferences.reference.ducrValue.error = Declaration Unique Consignment Reference is incorrect.
+consignmentReferences.reference.mucrValue.empty = Enter a Master Unique Consignment Reference
+consignmentReferences.reference.ducrValue.empty = Enter a Declaration Unique Consignment Reference
+consignmentReferences.reference.mucrValue.error = Master Unique Consignment Reference is incorrect
+consignmentReferences.reference.ducrValue.error = Declaration Unique Consignment Reference (DUCR) must be in the correct format. For example, 1GB123456789012-TRADER-REF-123
 
 specific.datetime.heading = Do you need to add a specific date and time for this request?
 specific.datetime.arrive.heading = Arrive consignment {0}
@@ -143,7 +143,7 @@ arrivalDetails.title = Arrival date and time
 arrivalDetails.sectionHeading = Arrive consignment {0}
 arrivalDetails.header = Enter date and time of arrival
 arrivalDetails.date.question = Date of arrival
-arrivalDetails.date.hint = For example, 1 8 2007
+arrivalDetails.date.hint = For example, 1 8 2021
 arrivalDetails.time.question = Time of arrival
 arrivalDetails.time.hint = Enter the time in 12 hour format. For example, 11 30 am.
 
@@ -154,7 +154,7 @@ departureDetails.title = Departure date and time
 departureDetails.sectionHeading = Depart consignment {0}
 departureDetails.header = Enter date and time of departure
 departureDetails.date.question = Date of departure
-departureDetails.date.hint = For example, 1 8 2007
+departureDetails.date.hint = For example, 1 8 2021
 departureDetails.time.question = Time of departure
 departureDetails.time.hint = Enter the time in 12 hour format. For example, 11 30 am.
 
@@ -181,12 +181,12 @@ transport.modeOfTransport.6 = Fixed transport installations
 transport.modeOfTransport.7 = Inland waterway transport
 transport.modeOfTransport.8 = Other, for example own propulsion
 transport.transportId.question = What is the ID for the selected transport type?
-transport.transportId.hint = This can be up to 35 characters. For example a vehicle registration number or an IATA flight number. If you selected postal or fixed installation, type 'Unknown' in the box.
+transport.transportId.hint = This can be up to 35 characters. For example a vehicle registration number or an IATA flight number. If you selected postal or fixed installation, type "Unknown" in the box.
 transport.transportId.empty = Enter the transport ID
 transport.transportId.error = Enter a transport ID that contains only letters and numbers
 transport.nationality.question = What country is the transport registered in?
-transport.nationality.empty = Select the country where the transport is registered.
-transport.nationality.error = Select the country where the transport is registered.
+transport.nationality.empty = Select the country where the transport is registered
+transport.nationality.error = Select the country where the transport is registered
 transport.nationality.country.help = Select a country from the list
 
 summary.referenceType = Consignment type
@@ -242,24 +242,27 @@ mucrOptions.hint.link = DE 2/1 in the UK Trade Tariff
 mucrOptions.title = Create or enter a Master Consignment Reference (MUCR) to associate with
 mucrOptions.create = Create a MUCR
 mucrOptions.add = Add to an existing MUCR
-mucrOptions.createAdd.value.empty = Select the option you want
-mucrOptions.reference.value.error = Select a valid option
+mucrOptions.error.unselected = Select if you want to create or add to a MUCR
+mucrOptions.reference.value.error.empty = Enter a MUCR
+mucrOptions.reference.value.error.invalid = MUCR must be in the correct format
 
 manageMucr.title = What do you want to associate?
 manageMucr.heading = Associate consignment {0}
-manageMucr.input.error.empty = Please, choose what do you want to do.
-manageMucr.input.error.incorrectValue = Please, choose valid option.
+manageMucr.input.error.empty = Select what you want to associate
+manageMucr.input.error.incorrectValue = Please, choose valid option
 manageMucr.associate.this.consignment = Associate this consignment to another
 manageMucr.associate.other.consignment = Associate another consignment to this one
-
-ducr.error.format = Declaration Unique Consignment Reference (DUCR) must be in the correct format. For example, 1GB123456789012-TRADER-REF-123
-mucr.error.format = Master Unique Consignment Reference (MUCR) must contain only letters, numbers, commas, hyphens and forward slash
 
 associate.ucr.title = Which consignment do you want to add to MUCR {0}?
 associate.ucr.heading = Which consignment do you want to add?
 associate.ucr.sectionHeader = Add to MUCR {0}
+associate.ucr.error.unselected = Select which consignment you want to add
 associate.ucr.ducr = Declaration Consignment Reference (DUCR)
+associate.ucr.ducr.error.empty = Enter a DUCR
+associate.ucr.ducr.error.invalid = Declaration Unique Consignment Reference (DUCR) must be in the correct format. For example, 1GB123456789012-TRADER-REF-123
 associate.ucr.mucr = Master Consignment Reference (MUCR)
+associate.ucr.mucr.error.empty = Enter a MUCR
+associate.ucr.mucr.error.invalid = Master Unique Consignment Reference (MUCR) must contain only letters, numbers, commas, hyphens and forward slash
 
 associate.ucr.hint = You may want to keep a record of which consignments you have added to this MUCR.
 
@@ -386,22 +389,24 @@ ileQueryResponse.links.manageConsignment = Manage this consignment
 ileQueryResponse.links.findConsignment = Find another consignment
 
 ileQueryResponse.ucrNotFound.title = The requested UCR does not exist
-ileQueryResponse.ucrNotFound.message = {0} does not exist.
+ileQueryResponse.ucrNotFound.message = {0} does not exist
 
 ileCode.unknown = Unknown
 
 ileQueryResponse.timeout.title = There is a problem
 ileQueryResponse.timeout.heading = Sorry, there is a problem with the service
-ileQueryResponse.timeout.message = Try again later.
+ileQueryResponse.timeout.message = Try again later
 
 ducrPartDetails.title = DUCR Part details
 ducrPartDetails.heading = You can use this service if your original declaration was made in CHIEF.
 ducrPartDetails.ducr = Enter DUCR
 ducrPartDetails.ducr.hint = For example, 9GB123999746000-DUCR12345.
-ducrPartDetails.ducr.error = Declaration Unique Consignment Reference (DUCR) must be in the correct format. For example, 1GB123456789012-TRADER-REF-123
+ducrPartDetails.ducr.empty = Enter a DUCR
+ducrPartDetails.ducr.invalid = Declaration Unique Consignment Reference (DUCR) must be in the correct format. For example, 1GB123456789012-TRADER-REF-123
 ducrPartDetails.ducrPartId = Enter DUCR Part ID
 ducrPartDetails.ducrPartId.hint = This can be up to 3 digits. For example, 123.
-ducrPartDetails.ducrPartId.error = Declaration Unique Consignment Reference (DUCR) must be in the correct format. For example, 1GB123456789012-TRADER-REF-123
+ducrPartDetails.ducrPartId.empty = Enter a part DUCR
+ducrPartDetails.ducrPartId.invalid = Part DUCR must be in the correct format. For example, 123
 
 ducrPartChief.ARRIVE.heading = Arrive consignment
 ducrPartChief.ARRIVE.question = Do you want to arrive a DUCR Part which was created in CHIEF?

--- a/test/it/AssociateUcrSpec.scala
+++ b/test/it/AssociateUcrSpec.scala
@@ -103,7 +103,7 @@ class AssociateUcrSpec extends IntegrationSpec {
     "GET" should {
       "return 200" in {
         givenAuthSuccess("eori")
-        givenCacheFor("eori", AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345"))))
+        givenCacheFor("eori", AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = "create", mucr = "GB/123-12345"))))
 
         val response = get(controllers.consolidations.routes.AssociateUcrController.displayPage())
 
@@ -114,7 +114,7 @@ class AssociateUcrSpec extends IntegrationSpec {
     "POST" should {
       "continue" in {
         givenAuthSuccess("eori")
-        givenCacheFor("eori", AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345"))))
+        givenCacheFor("eori", AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = "create", mucr = "GB/123-12345"))))
 
         val response = post(controllers.consolidations.routes.AssociateUcrController.submit(), "kind" -> "mucr", "mucr" -> "GB/321-54321")
 
@@ -122,7 +122,7 @@ class AssociateUcrSpec extends IntegrationSpec {
         redirectLocation(response) mustBe Some(controllers.consolidations.routes.AssociateUcrSummaryController.displayPage().url)
         theAnswersFor("eori") mustBe Some(
           AssociateUcrAnswers(
-            mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345")),
+            mucrOptions = Some(MucrOptions(createOrAdd = "create", mucr = "GB/123-12345")),
             associateUcr = Some(AssociateUcr(UcrType.Mucr, "GB/321-54321"))
           )
         )
@@ -137,7 +137,7 @@ class AssociateUcrSpec extends IntegrationSpec {
         givenCacheFor(
           "eori",
           AssociateUcrAnswers(
-            mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345")),
+            mucrOptions = Some(MucrOptions(createOrAdd = "create", mucr = "GB/123-12345")),
             associateUcr = Some(AssociateUcr(UcrType.Mucr, "GB/321-54321"))
           )
         )
@@ -154,7 +154,7 @@ class AssociateUcrSpec extends IntegrationSpec {
         givenCacheFor(
           "eori",
           AssociateUcrAnswers(
-            mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345")),
+            mucrOptions = Some(MucrOptions(createOrAdd = "create", mucr = "GB/123-12345")),
             associateUcr = Some(AssociateUcr(UcrType.Mucr, "GB/321-54321"))
           )
         )

--- a/test/it/AssociateUcrSpecWithIleQueryDisable.scala
+++ b/test/it/AssociateUcrSpecWithIleQueryDisable.scala
@@ -51,7 +51,7 @@ class AssociateUcrSpecWithIleQueryDisable extends IntegrationSpec {
 
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.consolidations.routes.AssociateUcrController.displayPage().url)
-        theAnswersFor("eori") mustBe Some(AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345"))))
+        theAnswersFor("eori") mustBe Some(AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = "create", mucr = "GB/123-12345"))))
       }
     }
   }
@@ -60,7 +60,7 @@ class AssociateUcrSpecWithIleQueryDisable extends IntegrationSpec {
     "GET" should {
       "return 200" in {
         givenAuthSuccess("eori")
-        givenCacheFor("eori", AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345"))))
+        givenCacheFor("eori", AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = "create", mucr = "GB/123-12345"))))
 
         val response = get(controllers.consolidations.routes.AssociateUcrController.displayPage())
 
@@ -71,7 +71,7 @@ class AssociateUcrSpecWithIleQueryDisable extends IntegrationSpec {
     "POST" should {
       "continue" in {
         givenAuthSuccess("eori")
-        givenCacheFor("eori", AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345"))))
+        givenCacheFor("eori", AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = "create", mucr = "GB/123-12345"))))
 
         val response = post(controllers.consolidations.routes.AssociateUcrController.submit(), "kind" -> "mucr", "mucr" -> "GB/321-54321")
 
@@ -79,7 +79,7 @@ class AssociateUcrSpecWithIleQueryDisable extends IntegrationSpec {
         redirectLocation(response) mustBe Some(controllers.consolidations.routes.AssociateUcrSummaryController.displayPage().url)
         theAnswersFor("eori") mustBe Some(
           AssociateUcrAnswers(
-            mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345")),
+            mucrOptions = Some(MucrOptions(createOrAdd = "create", mucr = "GB/123-12345")),
             associateUcr = Some(AssociateUcr(UcrType.Mucr, "GB/321-54321"))
           )
         )
@@ -94,7 +94,7 @@ class AssociateUcrSpecWithIleQueryDisable extends IntegrationSpec {
         givenCacheFor(
           "eori",
           AssociateUcrAnswers(
-            mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345")),
+            mucrOptions = Some(MucrOptions(createOrAdd = "create", mucr = "GB/123-12345")),
             associateUcr = Some(AssociateUcr(UcrType.Mucr, "GB/321-54321"))
           )
         )
@@ -111,7 +111,7 @@ class AssociateUcrSpecWithIleQueryDisable extends IntegrationSpec {
         givenCacheFor(
           "eori",
           AssociateUcrAnswers(
-            mucrOptions = Some(MucrOptions(createOrAdd = "create", newMucr = "GB/123-12345")),
+            mucrOptions = Some(MucrOptions(createOrAdd = "create", mucr = "GB/123-12345")),
             associateUcr = Some(AssociateUcr(UcrType.Mucr, "GB/321-54321"))
           )
         )

--- a/test/unit/controllers/consolidations/AssociateUcrControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUcrControllerSpec.scala
@@ -58,7 +58,7 @@ class AssociateUcrControllerSpec extends ControllerLayerSpec with MockCache {
   }
 
   "Associate Ducr controller" should {
-    val mucrOptions = MucrOptions("MUCR")
+    val mucrOptions = MucrOptions(MucrOptions.Create, "MUCR")
     val associateUcr = AssociateUcr(Ducr, "DUCR")
 
     "return OK (200)" when {

--- a/test/unit/controllers/consolidations/AssociateUcrSummaryControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUcrSummaryControllerSpec.scala
@@ -89,7 +89,7 @@ class AssociateUcrSummaryControllerSpec extends ControllerLayerSpec with ScalaFu
     (consignmentRefCaptor.getValue, associateWithCaptor.getValue, associateKindCaptor.getValue)
   }
 
-  private val mucrOptions = MucrOptions("MUCR")
+  private val mucrOptions = MucrOptions(MucrOptions.Create, "MUCR")
   private val associateUcr = AssociateUcr(Ducr, "DUCR")
 
   "Associate Ducr Summary Controller on displayPage" should {
@@ -111,7 +111,8 @@ class AssociateUcrSummaryControllerSpec extends ControllerLayerSpec with ScalaFu
       "display page when queried ducr" in {
         when(ileQueryConfig.isIleQueryEnabled) thenReturn true
         val result =
-          controller(AssociateUcrAnswers(None, Some(MucrOptions("MUCR")), Some(AssociateUcr(Ducr, "Queried DUCR")))).displayPage()(getRequest())
+          controller(AssociateUcrAnswers(None, Some(MucrOptions(MucrOptions.Create, "MUCR")), Some(AssociateUcr(Ducr, "Queried DUCR"))))
+            .displayPage()(getRequest())
 
         status(result) mustBe OK
         verify(mockAssociateDucrSummaryNoChangePage).apply(any(), any(), any(), any())(any(), any())
@@ -127,7 +128,7 @@ class AssociateUcrSummaryControllerSpec extends ControllerLayerSpec with ScalaFu
         val result = controller(
           AssociateUcrAnswers(
             Some(ManageMucrChoice(ManageMucrChoice.AssociateThisMucr)),
-            Some(MucrOptions("MUCR")),
+            Some(MucrOptions(MucrOptions.Create, "MUCR")),
             Some(AssociateUcr(Mucr, "Queried MUCR"))
           )
         ).displayPage()(getRequest())
@@ -146,7 +147,7 @@ class AssociateUcrSummaryControllerSpec extends ControllerLayerSpec with ScalaFu
         val result = controller(
           AssociateUcrAnswers(
             Some(ManageMucrChoice(ManageMucrChoice.AssociateAnotherMucr)),
-            Some(MucrOptions("Queried MUCR")),
+            Some(MucrOptions(MucrOptions.Create, "Queried MUCR")),
             Some(AssociateUcr(Ducr, "DUCR"))
           )
         ).displayPage()(getRequest())

--- a/test/unit/forms/AssociateUcrSpec.scala
+++ b/test/unit/forms/AssociateUcrSpec.scala
@@ -71,13 +71,47 @@ class AssociateUcrSpec extends BaseSpec {
     }
 
     "return an error" when {
-      "provided with Mucr that is over 35 characters long" in {
+      "radio option kind not present" in {
+        val form = AssociateUcr.form.bind(JsObject(Map("other" -> JsString(""))))
 
+        form.errors mustBe Seq(FormError("kind", List("associate.ucr.error.unselected")))
+      }
+
+      "radio option kind value neither Mucr or Ducr" in {
+        val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString(""))))
+
+        form.errors mustBe Seq(FormError("kind", List("associate.ucr.error.unselected")))
+      }
+
+      "provided with Mucr that is empty" in {
+        val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString("mucr"), "mucr" -> JsString(""))))
+
+        form.errors mustBe Seq(FormError("mucr", List("associate.ucr.mucr.error.empty")))
+      }
+
+      "provided with Mucr that is invalid" in {
+        val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString("mucr"), "mucr" -> JsString("invalid"))))
+
+        form.errors mustBe Seq(FormError("mucr", List("associate.ucr.mucr.error.invalid")))
+      }
+
+      "provided with Mucr that is over 35 characters long" in {
         val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString("mucr"), "mucr" -> JsString("gb/abced1234-15804test12345678901234"))))
 
-        form.errors mustBe Seq(FormError("mucr", List("mucr.error.format")))
+        form.errors mustBe Seq(FormError("mucr", List("associate.ucr.mucr.error.invalid")))
+      }
+
+      "provided with Ducr that is empty" in {
+        val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString("ducr"), "ducr" -> JsString(""))))
+
+        form.errors mustBe Seq(FormError("ducr", List("associate.ucr.ducr.error.empty")))
+      }
+
+      "provided with Ducr that is invalid" in {
+        val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString("ducr"), "ducr" -> JsString("invalid"))))
+
+        form.errors mustBe Seq(FormError("ducr", List("associate.ucr.ducr.error.invalid")))
       }
     }
   }
-
 }

--- a/test/unit/forms/DucrPartDetailsSpec.scala
+++ b/test/unit/forms/DucrPartDetailsSpec.scala
@@ -27,9 +27,6 @@ class DucrPartDetailsSpec extends BaseSpec {
 
     "return errors" when {
 
-      val expectedDucrError = FormError("ducr", Seq("ducrPartDetails.ducr.error"))
-      val expectedDucrPartIdError = FormError("ducrPartId", Seq("ducrPartDetails.ducrPartId.error"))
-
       "provided with empty DUCR" in {
 
         val input = Map("ducr" -> "", "ducrPartId" -> "")
@@ -38,7 +35,7 @@ class DucrPartDetailsSpec extends BaseSpec {
 
         result.isLeft mustBe true
         result.left.get.size mustBe 2
-        result.left.get must contain(expectedDucrError)
+        result.left.get must contain(FormError("ducr", Seq("ducrPartDetails.ducr.empty")))
       }
 
       "provided with incorrect DUCR" in {
@@ -49,29 +46,29 @@ class DucrPartDetailsSpec extends BaseSpec {
 
         result.isLeft mustBe true
         result.left.get.size mustBe 2
-        result.left.get must contain(expectedDucrError)
+        result.left.get must contain(FormError("ducr", Seq("ducrPartDetails.ducr.invalid")))
       }
 
       "provided with empty DUCR Part ID" in {
 
-        val input = Map("ducr" -> "", "ducrPartId" -> "")
+        val input = Map("ducr" -> validDucr, "ducrPartId" -> "")
 
         val result = DucrPartDetails.mapping.bind(input)
 
         result.isLeft mustBe true
-        result.left.get.size mustBe 2
-        result.left.get must contain(expectedDucrPartIdError)
+        result.left.get.size mustBe 1
+        result.left.get must contain(FormError("ducrPartId", Seq("ducrPartDetails.ducrPartId.empty")))
       }
 
       "provided with incorrect DUCR Part ID" in {
 
-        val input = Map("ducr" -> "incorrect!@#$%^", "ducrPartId" -> "incorrect!@#$%^")
+        val input = Map("ducr" -> validDucr, "ducrPartId" -> "incorrect!@#$%^")
 
         val result = DucrPartDetails.mapping.bind(input)
 
         result.isLeft mustBe true
-        result.left.get.size mustBe 2
-        result.left.get must contain(expectedDucrPartIdError)
+        result.left.get.size mustBe 1
+        result.left.get must contain(FormError("ducrPartId", Seq("ducrPartDetails.ducrPartId.invalid")))
       }
     }
 

--- a/test/unit/forms/MucrOptionsSpec.scala
+++ b/test/unit/forms/MucrOptionsSpec.scala
@@ -17,6 +17,7 @@
 package forms
 
 import base.BaseSpec
+import play.api.data.FormError
 import play.api.libs.json.{JsObject, JsString}
 
 class MucrOptionsSpec extends BaseSpec {
@@ -30,7 +31,7 @@ class MucrOptionsSpec extends BaseSpec {
       )
 
       form.errors mustBe (empty)
-      form.value.map(_.newMucr) must be(Some("GB/ABCED1234-15804TEST"))
+      form.value.map(_.mucr) must be(Some("GB/ABCED1234-15804TEST"))
     }
 
     "convert existing mucr to upper case" in {
@@ -40,8 +41,45 @@ class MucrOptionsSpec extends BaseSpec {
       )
 
       form.errors mustBe (empty)
-      form.value.map(_.existingMucr) must be(Some("GB/ABCED1234-15804TEST"))
+      form.value.map(_.mucr) must be(Some("GB/ABCED1234-15804TEST"))
+    }
+
+    "return an error" when {
+      "radio option createOrAdd not present" in {
+        val form = MucrOptions.form.bind(JsObject(Map("other" -> JsString(""))))
+
+        form.errors mustBe Seq(FormError("createOrAdd", List("mucrOptions.error.unselected")))
+      }
+
+      "radio option createOrAdd value neither create or add" in {
+        val form = MucrOptions.form.bind(JsObject(Map("createOrAdd" -> JsString(""))))
+
+        form.errors mustBe Seq(FormError("createOrAdd", List("mucrOptions.error.unselected")))
+      }
+
+      "provided with newMucr that is empty" in {
+        val form = MucrOptions.form.bind(JsObject(Map("createOrAdd" -> JsString("create"), "newMucr" -> JsString(""))))
+
+        form.errors mustBe Seq(FormError("newMucr", List("mucrOptions.reference.value.error.empty")))
+      }
+
+      "provided with newMucr that is invalid" in {
+        val form = MucrOptions.form.bind(JsObject(Map("createOrAdd" -> JsString("create"), "newMucr" -> JsString("invalid"))))
+
+        form.errors mustBe Seq(FormError("newMucr", List("mucrOptions.reference.value.error.invalid")))
+      }
+
+      "provided with existingMucr that is empty" in {
+        val form = MucrOptions.form.bind(JsObject(Map("createOrAdd" -> JsString("add"), "existingMucr" -> JsString(""))))
+
+        form.errors mustBe Seq(FormError("existingMucr", List("mucrOptions.reference.value.error.empty")))
+      }
+
+      "provided with existingMucr that is invalid" in {
+        val form = MucrOptions.form.bind(JsObject(Map("createOrAdd" -> JsString("add"), "existingMucr" -> JsString("invalid"))))
+
+        form.errors mustBe Seq(FormError("existingMucr", List("mucrOptions.reference.value.error.invalid")))
+      }
     }
   }
-
 }

--- a/test/unit/services/SubmissionServiceSpec.scala
+++ b/test/unit/services/SubmissionServiceSpec.scala
@@ -68,7 +68,7 @@ class SubmissionServiceSpec extends UnitSpec with MovementsMetricsStub with Befo
         given(connector.submit(any[Consolidation]())(any())).willReturn(Future.successful((): Unit))
         given(repository.removeByEori(anyString())).willReturn(Future.successful((): Unit))
 
-        val answers = AssociateUcrAnswers(None, Some(MucrOptions(mucr)), Some(AssociateUcr(UcrType.Ducr, ucr)))
+        val answers = AssociateUcrAnswers(None, Some(MucrOptions(MucrOptions.Create, mucr)), Some(AssociateUcr(UcrType.Ducr, ucr)))
         await(service.submit(validEori, answers))
 
         theAssociationSubmitted mustBe AssociateDUCRRequest(validEori, mucr, ucr)
@@ -80,7 +80,7 @@ class SubmissionServiceSpec extends UnitSpec with MovementsMetricsStub with Befo
         given(connector.submit(any[Consolidation]())(any())).willReturn(Future.successful((): Unit))
         given(repository.removeByEori(anyString())).willReturn(Future.successful((): Unit))
 
-        val answers = AssociateUcrAnswers(None, Some(MucrOptions(mucr)), Some(AssociateUcr(UcrType.Mucr, ucr)))
+        val answers = AssociateUcrAnswers(None, Some(MucrOptions(MucrOptions.Create, mucr)), Some(AssociateUcr(UcrType.Mucr, ucr)))
         await(service.submit(validEori, answers))
 
         theAssociationSubmitted mustBe AssociateMUCRRequest(validEori, mucr, ucr)
@@ -92,7 +92,7 @@ class SubmissionServiceSpec extends UnitSpec with MovementsMetricsStub with Befo
         given(connector.submit(any[Consolidation]())(any())).willReturn(Future.successful((): Unit))
         given(repository.removeByEori(anyString())).willReturn(Future.successful((): Unit))
 
-        val answers = AssociateUcrAnswers(None, Some(MucrOptions(mucr)), Some(AssociateUcr(UcrType.DucrPart, ucr)))
+        val answers = AssociateUcrAnswers(None, Some(MucrOptions(MucrOptions.Create, mucr)), Some(AssociateUcr(UcrType.DucrPart, ucr)))
         await(service.submit(validEori, answers))
 
         theAssociationSubmitted mustBe AssociateDUCRPartRequest(validEori, mucr, ucr)
@@ -104,7 +104,7 @@ class SubmissionServiceSpec extends UnitSpec with MovementsMetricsStub with Befo
     "audit when failed" in {
       given(connector.submit(any[Consolidation]())(any())).willReturn(Future.failed(new RuntimeException("Error")))
 
-      val answers = AssociateUcrAnswers(None, Some(MucrOptions(mucr)), Some(AssociateUcr(UcrType.Ducr, ucr)))
+      val answers = AssociateUcrAnswers(None, Some(MucrOptions(MucrOptions.Create, mucr)), Some(AssociateUcr(UcrType.Ducr, ucr)))
       intercept[RuntimeException] {
         await(service.submit(validEori, answers))
       }

--- a/test/unit/views/DucrPartDetailsViewSpec.scala
+++ b/test/unit/views/DucrPartDetailsViewSpec.scala
@@ -145,7 +145,7 @@ class DucrPartDetailsViewSpec extends ViewSpec with ViewMatchers with MockitoSug
 
     "provided with form containing DUCR error" should {
 
-      val form = DucrPartDetails.form().withError(FormError("ducr", "ducrPartDetails.ducr.error"))
+      val form = DucrPartDetails.form().withError(FormError("ducr", "ducrPartDetails.ducr.invalid"))
       val view: Document = createView(form)
 
       "render error summary" in {
@@ -155,13 +155,13 @@ class DucrPartDetailsViewSpec extends ViewSpec with ViewMatchers with MockitoSug
 
       "render field error" in {
 
-        view must haveGovUkFieldError("ducr", messages("ducrPartDetails.ducr.error"))
+        view must haveGovUkFieldError("ducr", messages("ducrPartDetails.ducr.invalid"))
       }
     }
 
     "provided with form containing DUCR Part ID error" should {
 
-      val form = DucrPartDetails.form().withError(FormError("ducrPartId", "ducrPartDetails.ducrPartId.error"))
+      val form = DucrPartDetails.form().withError(FormError("ducrPartId", "ducrPartDetails.ducrPartId.invalid"))
       val view: Document = createView(form)
 
       "render error summary" in {
@@ -171,9 +171,8 @@ class DucrPartDetailsViewSpec extends ViewSpec with ViewMatchers with MockitoSug
 
       "render field error" in {
 
-        view must haveGovUkFieldError("ducrPartId", messages("ducrPartDetails.ducrPartId.error"))
+        view must haveGovUkFieldError("ducrPartId", messages("ducrPartDetails.ducrPartId.invalid"))
       }
     }
   }
-
 }

--- a/test/unit/views/associateucr/AssociateUcrViewSpec.scala
+++ b/test/unit/views/associateucr/AssociateUcrViewSpec.scala
@@ -34,7 +34,7 @@ class AssociateUcrViewSpec extends ViewSpec with Injector {
 
   private val page = instanceOf[associate_ucr]
 
-  val mucrOptions = MucrOptions("MUCR")
+  val mucrOptions = MucrOptions(MucrOptions.Create, "MUCR")
 
   private def createView(mucr: MucrOptions, form: Form[AssociateUcr]): Html =
     page(form, mucr)(request, messages)
@@ -99,12 +99,12 @@ class AssociateUcrViewSpec extends ViewSpec with Injector {
     }
 
     "display DUCR Form errors" in {
-      val value = AssociateUcr.form.withError(FormError("ducr", "ducr.error.format"))
+      val value = AssociateUcr.form.withError(FormError("ducr", "associate.ucr.ducr.error.invalid"))
 
       val view: Document = createView(mucrOptions, value)
 
       view must haveGovUkGlobalErrorSummary
-      view must haveGovUkFieldError("ducr", messages("ducr.error.format"))
+      view must haveGovUkFieldError("ducr", messages("associate.ucr.ducr.error.invalid"))
     }
   }
 

--- a/test/unit/views/associateucr/MucrOptionsViewSpec.scala
+++ b/test/unit/views/associateucr/MucrOptionsViewSpec.scala
@@ -122,10 +122,10 @@ class MucrOptionsViewSpec extends ViewSpec with MockitoSugar with BeforeAndAfter
       }
 
       "some errors" in {
-        val view: Document = createView(form.withError(FormError("createOrAdd", "mucrOptions.createAdd.value.empty")))
+        val view: Document = createView(form.withError(FormError("createOrAdd", "mucrOptions.reference.value.error.empty")))
 
         view must haveGovUkGlobalErrorSummary
-        view must haveGovUkFieldError("createOrAdd", messages("mucrOptions.createAdd.value.empty"))
+        view must haveGovUkFieldError("createOrAdd", messages("mucrOptions.reference.value.error.empty"))
       }
     }
   }


### PR DESCRIPTION
Update text and remove full stops from end of validation error
messages.

Add separate error messages for empty vs invalid values.

Refactoring of the MucrOptions model class.