### PR TITLE
BAU Remove timeoutDialog.js file

### DIFF
--- a/app/assets/javascripts/timeoutDialog.js
+++ b/app/assets/javascripts/timeoutDialog.js
@@ -1,5 +1,0 @@
-const timeoutDialog = document.querySelector("#timeout-dialog");
-
-if (timeoutDialog && window.HMRCFrontend.TimeoutDialog) {
-    new window.HMRCFrontend.TimeoutDialog(timeoutDialog).init();
-}


### PR DESCRIPTION
This file is not needed for timeout to work correctly.