### PR TITLE
CEDS-3650 Add config to stop auditing asset requests

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -129,6 +129,13 @@ auditing {
   }
 }
 
+controllers {
+  # Avoid auditing requests for static assets to meet splunk storage requirements  
+  controllers.Assets.needsAuditing = false   
+  uk.gov.hmrc.govukfrontend.controllers.Assets.needsAuditing = false  
+  uk.gov.hmrc.hmrcfrontend.controllers.Assets.needsAuditing = false
+}
+
 allowList {
   eori: []
 }


### PR DESCRIPTION
To meet splunk storage requirements.