### PR TITLE
CEDS-4813 Secure Movements FE login on TDR with additional secret value.

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -36,10 +36,15 @@ class AppConfig @Inject() (
       .getOptional[String](key)
       .getOrElse(throw new Exception(s"Missing configuration key: $key"))
 
+  private def loadOptionalConfig(key: String): Option[String] =
+    runModeConfiguration.getOptional[String](key)
+
   lazy val appName: String = namedAppName
   lazy val keyStoreUrl: String = servicesConfig.baseUrl("keystore")
   lazy val sessionCacheDomain: String =
     servicesConfig.getConfString("cachable.session-cache.domain", throw new Exception(s"Could not find config 'cachable.session-cache.domain'"))
+
+  val maybeTdrHashSalt = loadOptionalConfig("secret.tdrHashSalt")
 
   val analyticsToken = loadConfig(s"google-analytics.token")
   val analyticsHost = loadConfig(s"google-analytics.host")
@@ -66,7 +71,7 @@ class AppConfig @Inject() (
 
   lazy val customsDeclareExportsMovements = servicesConfig.baseUrl("customs-declare-exports-movements")
 
-  lazy val selfBaseUrl: Option[String] = runModeConfiguration.getOptional[String]("play.frontend.host")
+  lazy val selfBaseUrl: Option[String] = loadOptionalConfig("play.frontend.host")
   val giveFeedbackLink: String =
     loadConfig("urls.exportsFeedbackForm")
 

--- a/app/controllers/actions/AuthAction.scala
+++ b/app/controllers/actions/AuthAction.scala
@@ -17,21 +17,28 @@
 package controllers.actions
 
 import com.google.inject.{ImplementedBy, Inject}
+import config.AppConfig
 import controllers.routes
 import models.SignedInUser
 import models.requests.AuthenticatedRequest
-import play.api.Configuration
+import models.AuthKey.{enrolment, eoriIdentifierKey, hashIdentifierKey}
+import play.api.{Configuration, Logging}
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import utils.HashingUtils.generateHashOfValue
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AuthActionImpl @Inject() (override val authConnector: AuthConnector, eoriAllowList: EoriAllowList, bodyParsers: PlayBodyParsers)(
-  implicit override val executionContext: ExecutionContext
-) extends AuthAction with AuthorisedFunctions {
+class AuthActionImpl @Inject() (
+  override val authConnector: AuthConnector,
+  eoriAllowList: EoriAllowList,
+  bodyParsers: PlayBodyParsers,
+  appConfig: AppConfig
+)(implicit override val executionContext: ExecutionContext)
+    extends AuthAction with AuthorisedFunctions with Logging {
 
   override val parser: BodyParser[AnyContent] = bodyParsers.anyContent
 
@@ -39,25 +46,59 @@ class AuthActionImpl @Inject() (override val authConnector: AuthConnector, eoriA
     implicit val hc: HeaderCarrier =
       HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
-    authorised(Enrolment("HMRC-CUS-ORG"))
+    authorised(Enrolment(enrolment))
       .retrieve(allEnrolments) { allEnrolments: Enrolments =>
-        val eori = allEnrolments
-          .getEnrolment("HMRC-CUS-ORG")
-          .flatMap(_.getIdentifier("EORINumber"))
+        val allUserEnrolments = allEnrolments.enrolments
 
-        if (eori.isEmpty) {
-          throw InsufficientEnrolments()
-        }
+        val eori = allUserEnrolments
+          .flatMap(_.getIdentifier(eoriIdentifierKey))
+          .headOption
+
+        validateEnrolments(eori)
+
+        val userProvidedEoriHash = allUserEnrolments
+          .flatMap(_.getIdentifier(hashIdentifierKey))
+          .map(_.value)
+          .headOption
+          .getOrElse("NoHashProvided")
 
         val cdsLoggedInUser = SignedInUser(eori.get.value, allEnrolments)
+        val maybeHiddenSalt = appConfig.maybeTdrHashSalt
 
-        if (eoriAllowList.contains(cdsLoggedInUser)) {
+        if (allowListAuthentication(cdsLoggedInUser.eori) && tdrSecretAuthentication(cdsLoggedInUser.eori, maybeHiddenSalt, userProvidedEoriHash))
           block(AuthenticatedRequest(request, cdsLoggedInUser))
-        } else {
+        else
           Future.successful(Results.Redirect(routes.UnauthorisedController.onPageLoad))
-        }
       }
   }
+
+  private def validateEnrolments(eori: Option[EnrolmentIdentifier]): Unit =
+    if (eori.isEmpty) {
+      logger.info("Authentication Rejected: User doesn't have an EORI set")
+      throw InsufficientEnrolments()
+    }
+
+  private def allowListAuthentication(eori: String): Boolean = {
+    val eoriOnAllowList = eoriAllowList.allows(eori)
+
+    if (!eoriOnAllowList)
+      logger.info("Authentication Rejected: User's EORI not on allow list")
+
+    eoriOnAllowList
+  }
+
+  private def tdrSecretAuthentication(eori: String, maybeHiddenSalt: Option[String], providedHash: String): Boolean =
+    maybeHiddenSalt match {
+      case None => true
+      case Some(hiddenSalt) =>
+        val hashOfPayload = generateHashOfValue(eori, hiddenSalt)
+        val matchingHash = providedHash.equalsIgnoreCase(hashOfPayload)
+
+        if (!matchingHash)
+          logger.info("Authentication Rejected: User's TDRSecret does not match")
+
+        matchingHash
+    }
 }
 
 @ImplementedBy(classOf[AuthActionImpl])
@@ -65,5 +106,5 @@ trait AuthAction extends ActionBuilder[AuthenticatedRequest, AnyContent] with Ac
 
 class EoriAllowList @Inject() (configuration: Configuration) {
   private val values = configuration.get[Seq[String]]("allowList.eori")
-  def contains(user: SignedInUser): Boolean = values.isEmpty || values.contains(user.eori)
+  def allows(eori: String): Boolean = values.isEmpty || values.contains(eori)
 }

--- a/app/models/AuthKey.scala
+++ b/app/models/AuthKey.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+object AuthKey {
+
+  val enrolment: String = "HMRC-CUS-ORG"
+  val eoriIdentifierKey: String = "EORINumber"
+  val hashIdentifierKey: String = "TDRSecret"
+}

--- a/app/utils/HashingUtils.scala
+++ b/app/utils/HashingUtils.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import org.apache.commons.codec.digest.HmacAlgorithms
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import javax.xml.bind.DatatypeConverter
+
+object HashingUtils {
+  private val algorithm = HmacAlgorithms.HMAC_SHA_256.toString
+
+  def generateHashOfValue(value: String, hiddenSalt: String): String = {
+    val secretSpec = new SecretKeySpec(hiddenSalt.getBytes(), algorithm)
+    val hmac = Mac.getInstance(algorithm)
+
+    hmac.init(secretSpec)
+
+    val sig = hmac.doFinal(value.getBytes("UTF-8"))
+    DatatypeConverter.printHexBinary(sig)
+  }
+}

--- a/app/views/unauthorisedEoriInTdr.scala.html
+++ b/app/views/unauthorisedEoriInTdr.scala.html
@@ -17,9 +17,11 @@
 @import config.ExternalServicesConfig
 @import views.html.components.gds._
 @import views.Title
+@import views.html.components.gds.link
 
 @this(
   govukLayout: gds_main_template,
+  link: link,
   pageTitle: pageTitle
 )
 
@@ -29,5 +31,13 @@
 
  @pageTitle(messages("unauthorised.tdr.heading"))
 
- @paragraphBody(messages("unauthorised.tdr.body"))
+ @paragraphBody(messages("unauthorised.tdr.body",
+  link(
+   id = Some("contact_support_link"),
+   message = Html(messages("unauthorised.tdr.body.link")),
+   href = Call("GET", s"mailto:${messages("unauthorised.tdr.body.link")}"),
+   target = "_blank"
+  )
+
+ ))
 }

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ lazy val microservice = Project(appName, file("."))
   .settings(commonSettings)
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
-  .settings(publishingSettings: _*)
   .settings(
     Test / unmanagedSourceDirectories := List((Test / baseDirectory).value / "test/unit", (Test / baseDirectory).value / "test/util"),
     addTestReportOption(Test, "test-reports")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -118,7 +118,6 @@ metrics {
 
 auditing {
   enabled = false
-  traceRequests = false
   consumer {
     baseUri {
       host = localhost
@@ -145,13 +144,6 @@ arriveDepartAllowList {
 google-analytics {
   token = N/A
   host = auto
-}
-
-assets {
-  version = "3.3.2"
-  #version = ${?ASSETS_FRONTEND_VERSION}
-  url = "http://localhost:9032/assets/"
-  url = ${?ASSETS_URL}
 }
 
 mongodb {

--- a/conf/messages
+++ b/conf/messages
@@ -79,8 +79,9 @@ unauthorised.paragraph.1.bullet.2.link = get access to the Customs Declaration S
 unauthorised.paragraph.2 = If you’ve already applied for an EORI number, you can {0}.
 unauthorised.paragraph.2.link = check the status of your application
 
-unauthorised.tdr.heading = The CDS Trader Dress Rehearsal Service for Making an Export Declaration Online is temporarily unavailable whilst we carry out a system update
-unauthorised.tdr.body = We will advise as soon as the update is complete.
+unauthorised.tdr.heading = The EORI you entered is not valid on the customs declaration test service
+unauthorised.tdr.body = You need to contact {0} to ensure access has been set up for your EORI number.
+unauthorised.tdr.body.link = cdsexportsuiteam@hmrc.gov.uk
 
 global.error.title = There is a problem - Declare customs exports for CDS Exports - GOV.UK
 global.error.heading = There is a problem with a service.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -21,7 +21,8 @@ object AppDependencies {
     "ai.x"                         %% "play-json-extensions"          % "0.42.0",
     "com.github.tototoshi"         %% "scala-csv"                     % "1.3.10",
     "org.webjars.npm"              %  "govuk-frontend"                % "4.4.1",
-    "org.webjars.npm"              %  "accessible-autocomplete"       % "2.0.4"
+    "org.webjars.npm"              %  "accessible-autocomplete"       % "2.0.4",
+    "commons-codec"                %  "commons-codec"                 % "1.15"
   )
 
   val testScope = "test,it"

--- a/test/unit/base/MockAuthConnector.scala
+++ b/test/unit/base/MockAuthConnector.scala
@@ -17,13 +17,14 @@
 package base
 
 import akka.stream.testkit.NoMaterializer
+import config.AppConfig
 import controllers.actions.{AuthActionImpl, EoriAllowList}
 import models.SignedInUser
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.MockitoSugar.{mock, when}
 import play.api.mvc.PlayBodyParsers
-import testdata.CommonTestData.validEori
+import testdata.CommonTestData.{validEori, validTdrSecret}
 import testdata.MovementsTestData._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
@@ -32,22 +33,24 @@ import utils.Stubs
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.Future
 
-trait MockAuthConnector extends Stubs {
+trait MockAuthConnector extends Stubs with Injector {
 
   val authConnectorMock: AuthConnector = mock[AuthConnector]
 
   val eoriAllowListMock: EoriAllowList = mock[EoriAllowList]
 
-  val mockAuthAction =
-    new AuthActionImpl(authConnectorMock, eoriAllowListMock, PlayBodyParsers()(NoMaterializer))(global)
+  val appConfig = mock[AppConfig]
 
-  def authorizedUser(user: SignedInUser = newUser(validEori)): Unit = {
+  val mockAuthAction =
+    new AuthActionImpl(authConnectorMock, eoriAllowListMock, PlayBodyParsers()(NoMaterializer), appConfig)(global)
+
+  def authorizedUser(user: SignedInUser = newUser(validEori, Some(validTdrSecret))): Unit = {
     when(authConnectorMock.authorise(any(), ArgumentMatchers.eq(allEnrolments))(any(), any())).thenReturn(Future.successful(user.enrolments))
-    when(eoriAllowListMock.contains(any())).thenReturn(true)
+    when(eoriAllowListMock.allows(any())).thenReturn(true)
   }
 
   def userWithoutEori(user: SignedInUser = newUser("")): Unit = {
     when(authConnectorMock.authorise(any(), ArgumentMatchers.eq(allEnrolments))(any(), any())).thenThrow(InsufficientEnrolments())
-    when(eoriAllowListMock.contains(any())).thenReturn(true)
+    when(eoriAllowListMock.allows(any())).thenReturn(true)
   }
 }

--- a/test/unit/config/AppConfigSpec.scala
+++ b/test/unit/config/AppConfigSpec.scala
@@ -78,6 +78,8 @@ class AppConfigSpec extends AnyWordSpec with Matchers {
         |microservice.services.contact-frontend.url=/contact-frontend-url
         |microservice.services.contact-frontend.serviceId=Movements-Service-ID
         |play.frontend.host="self/base-url"
+        |
+        |secret.tdrHashSalt="SomeSuperSecret"
       """.stripMargin)
 
   private val missingValuesAppConfig: Config =
@@ -234,6 +236,14 @@ class AppConfigSpec extends AnyWordSpec with Matchers {
     "have selfBaseUrl" in {
       validConfigService.selfBaseUrl must be(defined)
       validConfigService.selfBaseUrl.get must be("self/base-url")
+    }
+
+    "have tdrHashSalt" in {
+      validConfigService.maybeTdrHashSalt must be(Some("SomeSuperSecret"))
+    }
+
+    "empty tdrHashSalt when the key is missing" in {
+      emptyConfigService.maybeTdrHashSalt must be(None)
     }
 
     "have feedback link" in {

--- a/test/unit/controllers/ControllerLayerSpec.scala
+++ b/test/unit/controllers/ControllerLayerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import base.{MockNavigator, UnitSpec}
+import base.{MockAuthConnector, MockNavigator, UnitSpec}
 import controllers.actions._
 import forms.DucrPartChiefChoice
 import models.cache.JourneyType.JourneyType
@@ -38,7 +38,7 @@ import utils.Stubs
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-abstract class ControllerLayerSpec extends UnitSpec with BeforeAndAfterEach with CSRFSupport with Stubs with MockNavigator {
+abstract class ControllerLayerSpec extends UnitSpec with BeforeAndAfterEach with CSRFSupport with Stubs with MockNavigator with MockAuthConnector {
 
   protected val user = SignedInUser("eori", Enrolments(Set.empty))
   protected def getRequest(): Request[AnyContent] = FakeRequest(GET, "/").withCSRFToken
@@ -57,12 +57,13 @@ abstract class ControllerLayerSpec extends UnitSpec with BeforeAndAfterEach with
   protected def contentAsHtml(of: Future[Result]): Html = Html(contentAsBytes(of).decodeString(charset(of).getOrElse("utf-8")))
 
   case class SuccessfulAuth(operator: SignedInUser = user)
-      extends AuthActionImpl(mock[AuthConnector], mock[EoriAllowList], stubMessagesControllerComponents().parsers) {
+      extends AuthActionImpl(mock[AuthConnector], mock[EoriAllowList], stubMessagesControllerComponents().parsers, appConfig) {
     override def invokeBlock[A](request: Request[A], block: AuthenticatedRequest[A] => Future[Result]): Future[Result] =
       block(AuthenticatedRequest(request, operator))
   }
 
-  case object UnsuccessfulAuth extends AuthActionImpl(mock[AuthConnector], mock[EoriAllowList], stubMessagesControllerComponents().parsers) {
+  case object UnsuccessfulAuth
+      extends AuthActionImpl(mock[AuthConnector], mock[EoriAllowList], stubMessagesControllerComponents().parsers, appConfig) {
     override def invokeBlock[A](request: Request[A], block: AuthenticatedRequest[A] => Future[Result]): Future[Result] =
       Future.successful(Results.Forbidden)
   }

--- a/test/unit/controllers/actions/EoriAllowListSpec.scala
+++ b/test/unit/controllers/actions/EoriAllowListSpec.scala
@@ -35,19 +35,18 @@ class EoriAllowListSpec extends UnitSpec {
     "is empty" should {
       "pass everyone" in {
         val allowList = new EoriAllowList(emptyListConfig)
-        allowList.contains(firstUser) mustBe true
-        allowList.contains(secondUser) mustBe true
+        allowList.allows(firstUser.eori) mustBe true
+        allowList.allows(secondUser.eori) mustBe true
       }
     }
     "has entry in list" should {
       val allowList = new EoriAllowList(config)
       "allow users on list" in {
-        allowList.contains(firstUser) mustBe true
+        allowList.allows(firstUser.eori) mustBe true
       }
       "block user absent on list" in {
-        allowList.contains(secondUser) mustBe false
+        allowList.allows(secondUser.eori) mustBe false
       }
     }
-
   }
 }

--- a/test/unit/handlers/ErrorHandlerSpec.scala
+++ b/test/unit/handlers/ErrorHandlerSpec.scala
@@ -16,16 +16,16 @@
 
 package handlers
 
-import config.AppConfig
 import controllers.ControllerLayerSpec
 import controllers.exception.IncompleteApplication
-import controllers.routes.RootController
 import models.ReturnToStartException
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.refEq
 import org.mockito.BDDMockito.`given`
 import org.mockito.MockitoSugar.{mock, reset, verify}
 import play.api.http.{HeaderNames, Status}
+import controllers.routes.RootController
+import models.AuthKey.enrolment
 import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.mvc.RequestHeader
 import play.api.test.FakeRequest
@@ -37,7 +37,6 @@ import scala.concurrent.Future.successful
 
 class ErrorHandlerSpec extends ControllerLayerSpec {
 
-  private val appConfig = mock[AppConfig]
   private val errorPage = mock[views.html.error_template]
   private val errorPageHTML = HtmlFormat.empty
   private val messagesApi = mock[MessagesApi]
@@ -101,7 +100,7 @@ class ErrorHandlerSpec extends ControllerLayerSpec {
 
     "handle insufficient enrolments authorisation exception" in {
       val res =
-        errorHandler.resolveError(req, InsufficientEnrolments("HMRC-CUS-ORG"))
+        errorHandler.resolveError(req, InsufficientEnrolments(enrolment))
       res.header.status must be(Status.SEE_OTHER)
       res.header.headers.get(HeaderNames.LOCATION) must be(Some(controllers.routes.UnauthorisedController.onPageLoad.url))
     }

--- a/test/unit/testdata/CommonTestData.scala
+++ b/test/unit/testdata/CommonTestData.scala
@@ -19,6 +19,7 @@ package testdata
 object CommonTestData {
 
   val validEori: String = "GB12345678"
+  val validTdrSecret = "8E077FEDD75D98AC8B9823E62C73F2E5598CCDEA42C6CF7041B1D394520DE330"
 
   val correctUcr: String = "GB/1UZYBD3XE-1J8MEBF9N6X65B"
   val correctUcr_2: String = "GB/1UZYBD3XE-1J8MEBF9N6X78C"

--- a/test/unit/testdata/MovementsTestData.scala
+++ b/test/unit/testdata/MovementsTestData.scala
@@ -27,6 +27,7 @@ import models.now
 import models.cache.{ArrivalAnswers, DepartureAnswers, IleQuery}
 import models.submissions.Submission
 import models.{SignedInUser, UcrBlock}
+import models.AuthKey.{enrolment, eoriIdentifierKey, hashIdentifierKey}
 import testdata.CommonTestData._
 import uk.gov.hmrc.auth.core.{Enrolment, Enrolments}
 
@@ -35,8 +36,13 @@ object MovementsTestData {
   private val zoneId: ZoneId = ZoneId.of("Europe/London")
   val movementDetails = new MovementDetails(zoneId)
 
-  def newUser(eori: String): SignedInUser =
-    SignedInUser(eori, Enrolments(Set(Enrolment("HMRC-CUS-ORG").withIdentifier("EORINumber", eori))))
+  def newUser(eori: String, tdrSecret: Option[String] = None): SignedInUser = {
+    val eoriEnrolment = Set(Enrolment(enrolment).withIdentifier(eoriIdentifierKey, eori))
+    val enrolmentSet =
+      tdrSecret.map(secret => eoriEnrolment + Enrolment(enrolment).withIdentifier(hashIdentifierKey, secret)).getOrElse(eoriEnrolment)
+
+    SignedInUser(eori, Enrolments(enrolmentSet))
+  }
 
   def exampleSubmission(
     eori: String = validEori,

--- a/test/unit/views/UnauthorisedEoriInTdrViewSpec.scala
+++ b/test/unit/views/UnauthorisedEoriInTdrViewSpec.scala
@@ -32,5 +32,13 @@ class UnauthorisedEoriInTdrViewSpec extends ViewSpec with Injector {
     "display page header" in {
       view.getElementsByTag("h1").first() must containMessage("unauthorised.tdr.heading")
     }
+
+    "display the expected contact email address link" in {
+      val link = view.getElementById("contact_support_link")
+
+      link must containMessage("unauthorised.tdr.body.link")
+      link must haveHref(s"mailto:${messages("unauthorised.tdr.body.link")}")
+      link.attr("target") mustBe "_blank"
+    }
   }
 }

--- a/test/util/connectors/AuthWiremockTestServer.scala
+++ b/test/util/connectors/AuthWiremockTestServer.scala
@@ -17,6 +17,7 @@
 package connectors
 
 import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, urlEqualTo}
+import models.AuthKey.{enrolment, eoriIdentifierKey}
 import play.api.Configuration
 import play.api.libs.json.Json
 import play.api.test.Helpers.{OK, UNAUTHORIZED}
@@ -26,7 +27,7 @@ trait AuthWiremockTestServer extends WiremockTestServer {
 
   protected val authConfiguration: Configuration = Configuration.from(Map("microservice.services.auth.port" -> wirePort))
 
-  protected def givenAuthSuccess(eori: String): Unit = givenAuthSuccess(Enrolment("HMRC-CUS-ORG", Seq(EnrolmentIdentifier("EORINumber", eori)), ""))
+  protected def givenAuthSuccess(eori: String): Unit = givenAuthSuccess(Enrolment(enrolment, Seq(EnrolmentIdentifier(eoriIdentifierKey, eori)), ""))
 
   protected def givenAuthSuccess(roles: Enrolment*): Unit = {
     val response = Json.obj("allEnrolments" -> roles.map { role =>


### PR DESCRIPTION
Adding new 'secret.tdrHashSalt' config value that will only be set in the TDR environment.

Adding additional authentication check that if the 'tdrHashSalt' value is present in config, then the user must specify an additional HMRC-CUS-ORG enrolment value of 'TDRSecret' who's value must be a valid hash of the supplied 'EORINumber' value.