### PR TITLE
CEDS-5250 - Fixing VNU issues

### DIFF
--- a/app/views/components/gds/exportsInputText.scala.html
+++ b/app/views/components/gds/exportsInputText.scala.html
@@ -24,13 +24,14 @@
         hintContent: Option[Content] = None,
         isPageHeading: Boolean = false,
         headingClasses: String = "govuk-label--l",
-        inputClasses: String = "govuk-!-width-two-thirds"
+        inputClasses: String = "govuk-!-width-two-thirds",
+        labelClasses: String = "govuk-label govuk-label--m"
 )(implicit messages: Messages)
 
 @buildLabel = @{ if(isPageHeading) {
     Label(content = Text(messages(labelKey)), isPageHeading = true,  classes = headingClasses)
   } else {
-    Label(content = Text(messages(labelKey)), classes = "govuk-label govuk-label--m")
+    Label(content = Text(messages(labelKey)), classes = labelClasses)
   }
 }
 

--- a/app/views/components/gds/gds_main_template.scala.html
+++ b/app/views/components/gds/gds_main_template.scala.html
@@ -69,8 +69,6 @@
       )
   }
 
-    @hmrcTrackingConsentSnippet()
-
     <link rel="shortcut icon" href='@routes.Assets.versioned("/lib/govuk-frontend/govuk/assets/images/favicon.ico")' type="image/x-icon" />
     <link rel="shortcut icon" href='@routes.Assets.versioned("lib/accessible-autocomplete/dist/accessible-autocomplete.min.css")' rel="stylesheet" type="text/css" />
     <meta name="format-detection" content="telephone=no" />
@@ -89,10 +87,9 @@
         .hmrc-header__service-name--linked:link, .hmrc-header__service-name--linked:visited {
           color: #000;
         }
-        .hmrc-language-select__list-item {
-          &:first-child::after {
-            border: none;
-          }
+        .hmrc-language-select__list-item,
+        .hmrc-language-select__list-item:first-child::after {
+          border: none;
         }
         .govuk-link[href^="/"]::after, .govuk-link[href^="http://"]::after, .govuk-link[href^="https://"]::after {
           content: normal;

--- a/app/views/location.scala.html
+++ b/app/views/location.scala.html
@@ -42,10 +42,8 @@
 }}
 
 @heading = {
-    <h1 class="govuk-label-wrapper">
-        <label class="govuk-label govuk-label--l" for="code">
-            @messages("location.question")
-        </label>
+    <h1 class="govuk-heading govuk-heading-xl">
+        @messages("location.question")
     </h1>
 }
 
@@ -69,9 +67,8 @@
         @exportsInputText(
             field = form("code"),
             labelKey = "location.question",
-            hintContent = Some(HtmlContent(hint)),
-            isPageHeading = true,
-            headingClasses = "govuk-visually-hidden"
+            labelClasses = "govuk-visually-hidden",
+            hintContent = Some(HtmlContent(hint))
         )
 
         @goodsLocationExpander()


### PR DESCRIPTION
Removing @hmrcTrackingConsentSnippet() as it seems to be pulled in by the template - causing a duplicate consent script to be called on pages. After removal this is still present on the page as expected:

<script
     nonce="TtQbtiTBUtVhSJ8p1Upm1Q==" 
    src="[http://localhost:12345/tracking-consent/tracking.js](view-source:http://localhost:12345/tracking-consent/tracking.js)"
    id="tracking-consent-script-tag"
    data-gtm-container="a"
    data-language="en"
  ></script>